### PR TITLE
Wire real APIs into Scout, Scraper, Builder, and Postman

### DIFF
--- a/dashboard/server/agents/Builder.js
+++ b/dashboard/server/agents/Builder.js
@@ -1,5 +1,6 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getSetting } from '../database.js';
+import Anthropic from '@anthropic-ai/sdk';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -79,9 +80,22 @@ export class Builder extends BaseAgent {
     const category = business.category || 'default';
     const design = DESIGN_STYLES[category] || DESIGN_STYLES.default;
 
-    // Generate about text (mock LLM — replace with real API call)
-    const about = this.generateAbout(business);
-    const tagline = this.generateTagline(business);
+    // Use real Claude when key is set; fall back to templates otherwise.
+    const anthropicKey = getSetting('anthropic_api_key');
+    let about;
+    let tagline;
+    if (anthropicKey) {
+      try {
+        ({ about, tagline } = await this.generateCopyWithClaude(business, anthropicKey));
+      } catch (err) {
+        this.log(`Claude copy failed (${err.message}) — falling back to templates`, 'warning');
+        about = this.generateAbout(business);
+        tagline = this.generateTagline(business);
+      }
+    } else {
+      about = this.generateAbout(business);
+      tagline = this.generateTagline(business);
+    }
 
     const html = this.generateHtml(business, design, about, tagline);
 
@@ -108,8 +122,50 @@ export class Builder extends BaseAgent {
     };
   }
 
+  // Real Claude copy generation. Haiku for minimum token cost (~$0.001 per site).
+  // Returns { about, tagline } — structured JSON so we never have to parse prose.
+  async generateCopyWithClaude(biz, apiKey) {
+    const client = new Anthropic({ apiKey });
+    const reviews = Array.isArray(biz.reviews)
+      ? biz.reviews
+          .slice(0, 3)
+          .map((r) => `- (${r.rating}★) ${String(r.text || '').slice(0, 220)}`)
+          .join('\n')
+      : '';
+    const userInput = [
+      `Name: ${biz.name}`,
+      `Category: ${biz.category || 'local business'}`,
+      `Address: ${biz.address || ''}`,
+      biz.rating ? `Rating: ${biz.rating} (${biz.review_count || 0} reviews)` : '',
+      biz.editorial_summary ? `Editorial: ${biz.editorial_summary}` : '',
+      reviews ? `Top reviews:\n${reviews}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 400,
+      system:
+        'You write short, grounded website copy for small local businesses. ' +
+        'No jargon, no marketing clichés ("dedicated to", "nestled", "where quality meets"). ' +
+        'Base every line on the business data provided; never invent credentials or services. ' +
+        'Return ONLY valid JSON matching: {"tagline": "5-9 word phrase", "about": "50-90 word paragraph (2-3 sentences)"}',
+      messages: [{ role: 'user', content: userInput }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const raw = textBlock?.text?.trim() || '';
+    // Strip accidental markdown fences if the model adds them.
+    const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+    const parsed = JSON.parse(cleaned);
+    if (!parsed.about || !parsed.tagline) {
+      throw new Error('Claude returned incomplete copy JSON');
+    }
+    return { about: parsed.about, tagline: parsed.tagline };
+  }
+
   generateAbout(biz) {
-    // TODO: Replace with real LLM API call
     const templates = [
       `Welcome to ${biz.name}! We've been proudly serving our community with dedication and passion. Our team is committed to providing you with the highest quality ${biz.category === 'restaurant' ? 'dining experience' : 'service'} every single time you visit us.`,
       `At ${biz.name}, we believe in putting our customers first. With a stellar ${biz.rating}-star rating from ${biz.review_count} happy customers, we're proud to be a trusted name in our neighborhood. Come see why our community loves us!`,

--- a/dashboard/server/agents/Postman.js
+++ b/dashboard/server/agents/Postman.js
@@ -63,23 +63,48 @@ export class Postman extends BaseAgent {
   }
 
   async sendViaApi(to, subject, body, apiKey) {
-    // TODO: Replace with real SendGrid/Mailgun/SES API call
-    // Example SendGrid:
-    // const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
-    //   method: 'POST',
-    //   headers: {
-    //     'Authorization': `Bearer ${apiKey}`,
-    //     'Content-Type': 'application/json',
-    //   },
-    //   body: JSON.stringify({
-    //     personalizations: [{ to: [{ email: to }] }],
-    //     from: { email: getSetting('sendgrid_from_email') },
-    //     subject,
-    //     content: [{ type: 'text/plain', value: body }],
-    //   }),
-    // });
+    const fromEmail = getSetting('sendgrid_from_email');
+    if (!fromEmail) {
+      this.logIssue(
+        'SENDGRID_FROM_EMAIL not set — cannot send real emails',
+        'error',
+        'Set SENDGRID_FROM_EMAIL in your .env and make sure the sending domain has SPF + DKIM configured in SendGrid.',
+      );
+      return;
+    }
 
-    this.log(`[API] Would send email to ${to} via SendGrid`, 'info');
-    await new Promise((r) => setTimeout(r, 300));
+    try {
+      const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: to }] }],
+          from: { email: fromEmail, name: 'Website Scaler' },
+          subject,
+          content: [{ type: 'text/plain', value: body }],
+          tracking_settings: {
+            click_tracking: { enable: true, enable_text: false },
+            open_tracking: { enable: true },
+          },
+        }),
+      });
+
+      // SendGrid returns 202 Accepted on success with empty body.
+      if (res.status === 202) {
+        this.log(`Sent pitch to ${to} via SendGrid`, 'success');
+        return;
+      }
+      const errText = await res.text();
+      this.logIssue(
+        `SendGrid ${res.status} for ${to}: ${errText.slice(0, 200)}`,
+        'error',
+        'Verify the API key, sending domain authentication, and that the recipient isn\'t on a suppression list.',
+      );
+    } catch (err) {
+      this.logIssue(`Email send failed for ${to}: ${err.message}`, 'error');
+    }
   }
 }

--- a/dashboard/server/agents/Scout.js
+++ b/dashboard/server/agents/Scout.js
@@ -49,22 +49,108 @@ export class Scout extends BaseAgent {
   }
 
   async findBusinessesFromApi(zipCode, category, limit, apiKey) {
-    // TODO: Replace with real Google Maps Places API call
-    // const url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${lat},${lng}&radius=5000&type=${category}&key=${apiKey}`;
-    // const response = await fetch(url);
-    // const data = await response.json();
-    // Filter for businesses without websites
-    // Return normalized results
+    // Places API (New) v1 Text Search. Field mask keeps cost minimal — we only
+    // pay for fields we request. `websiteUri` is how we filter: if the listing
+    // has a website, we skip it (that's our qualifier — they don't need us).
+    const query = `${category === 'all' ? 'businesses' : category} in ${zipCode}`;
+    const fieldMask = [
+      'places.id',
+      'places.displayName',
+      'places.formattedAddress',
+      'places.types',
+      'places.websiteUri',
+      'places.rating',
+      'places.userRatingCount',
+      'places.nationalPhoneNumber',
+      'places.location',
+      'places.googleMapsUri',
+      'nextPageToken',
+    ].join(',');
 
-    this.log(`[API] Would search Google Maps for ${category} in ${zipCode}`, 'info');
-    await this.simulateDelay(1000, 3000);
+    const qualified = [];
+    let pageToken;
+    let requestsMade = 0;
 
-    // Fallback to mock for now
-    return MOCK_BUSINESSES.slice(0, limit).map((b) => ({
-      ...b,
-      place_id: `api_${b.place_id}_${Date.now()}`,
-      address: `${b.address}, ${zipCode}`,
-    }));
+    try {
+      do {
+        const body = { textQuery: query, pageSize: 20 };
+        if (pageToken) body.pageToken = pageToken;
+
+        const res = await fetch('https://places.googleapis.com/v1/places:searchText', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Goog-Api-Key': apiKey,
+            'X-Goog-FieldMask': fieldMask,
+          },
+          body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+          const text = await res.text();
+          this.logIssue(
+            `Google Maps API ${res.status}: ${text.slice(0, 200)}`,
+            'error',
+            'Check the GOOGLE_MAPS_API_KEY and enable Places API in Google Cloud Console.',
+          );
+          break;
+        }
+
+        const data = await res.json();
+        requestsMade++;
+
+        for (const p of data.places || []) {
+          if (p.websiteUri) continue; // already has a site — skip
+          qualified.push({
+            place_id: p.id,
+            name: p.displayName?.text || '',
+            category: category || this.inferCategory(p.types),
+            rating: p.rating,
+            review_count: p.userRatingCount,
+            address: p.formattedAddress || '',
+            phone: p.nationalPhoneNumber,
+            latitude: p.location?.latitude,
+            longitude: p.location?.longitude,
+            maps_url: p.googleMapsUri,
+          });
+          if (qualified.length >= limit) break;
+        }
+
+        pageToken = data.nextPageToken;
+      } while (pageToken && qualified.length < limit && requestsMade < 3);
+
+      this.log(
+        `Found ${qualified.length} businesses without websites in ${zipCode} (${requestsMade} API calls)`,
+        qualified.length > 0 ? 'success' : 'warning',
+      );
+      this.completeTask();
+      return qualified;
+    } catch (err) {
+      this.logIssue(`Scout API call failed: ${err.message}`, 'error');
+      return [];
+    }
+  }
+
+  inferCategory(types = []) {
+    const map = {
+      restaurant: 'restaurant',
+      cafe: 'restaurant',
+      bakery: 'bakery',
+      bar: 'restaurant',
+      beauty_salon: 'salon',
+      hair_care: 'salon',
+      nail_salon: 'salon',
+      spa: 'salon',
+      gym: 'gym',
+      dentist: 'dentist',
+      doctor: 'dentist',
+      lawyer: 'lawyer',
+      florist: 'florist',
+      car_repair: 'auto_repair',
+      pet_store: 'pet_service',
+    };
+    for (const t of types) if (map[t]) return map[t];
+    return types[0] || 'other';
   }
 
   simulateDelay(min, max) {

--- a/dashboard/server/agents/Scraper.js
+++ b/dashboard/server/agents/Scraper.js
@@ -1,4 +1,5 @@
 import { BaseAgent } from './BaseAgent.js';
+import { getSetting } from '../database.js';
 
 const MOCK_OWNERS = [
   { name: 'Rosa Martinez', email: 'rosa@mamabakery.com' },
@@ -46,12 +47,14 @@ export class Scraper extends BaseAgent {
     this.heartbeat();
     this.log(`Enriching data for ${business.name}`, 'info');
 
-    await this.simulateDelay(500, 1500);
+    const apiKey = getSetting('google_maps_api_key');
+    if (apiKey && business.place_id && !business.place_id.startsWith('mock_')) {
+      const live = await this.enrichFromApi(business, apiKey);
+      if (live) return live;
+      // fall through to mock if the API call failed
+    }
 
-    // In real implementation, this would:
-    // 1. Call Google Places Details API for full info
-    // 2. Scrape web for owner email (LinkedIn, public records, etc.)
-    // 3. Validate and clean data
+    await this.simulateDelay(500, 1500);
 
     const ownerIdx = Math.floor(Math.random() * MOCK_OWNERS.length);
     const owner = MOCK_OWNERS[ownerIdx];
@@ -90,5 +93,102 @@ export class Scraper extends BaseAgent {
   simulateDelay(min, max) {
     const delay = Math.floor(Math.random() * (max - min)) + min;
     return new Promise((r) => setTimeout(r, delay));
+  }
+
+  async enrichFromApi(business, apiKey) {
+    // Places API (New) — Place Details. Field mask = cost control.
+    // Note: owner email is not a public field; we keep the mock owner email
+    // for now. A real deploy would plug in Hunter.io or a domain-guess fallback.
+    const fieldMask = [
+      'id',
+      'displayName',
+      'formattedAddress',
+      'nationalPhoneNumber',
+      'regularOpeningHours',
+      'rating',
+      'userRatingCount',
+      'photos',
+      'reviews',
+      'editorialSummary',
+      'websiteUri',
+      'googleMapsUri',
+    ].join(',');
+
+    try {
+      const res = await fetch(`https://places.googleapis.com/v1/places/${business.place_id}`, {
+        headers: { 'X-Goog-Api-Key': apiKey, 'X-Goog-FieldMask': fieldMask },
+      });
+      if (!res.ok) {
+        this.log(`Places Details ${res.status} for ${business.name} — falling back to mock`, 'warning');
+        return null;
+      }
+      const p = await res.json();
+
+      // Convert weekdayDescriptions → { monday: "9am-5pm", ... }
+      const hours = {};
+      for (const line of p.regularOpeningHours?.weekdayDescriptions || []) {
+        const [day, ...rest] = line.split(':');
+        if (day && rest.length) hours[day.trim().toLowerCase()] = rest.join(':').trim();
+      }
+
+      // Photos: resolve the first 3 to usable URLs. `skipHttpRedirect` returns
+      // JSON with the final photo URL instead of a redirect.
+      const photos = [];
+      for (const ph of (p.photos || []).slice(0, 3)) {
+        try {
+          const pr = await fetch(
+            `https://places.googleapis.com/v1/${ph.name}/media?maxWidthPx=1200&skipHttpRedirect=true`,
+            { headers: { 'X-Goog-Api-Key': apiKey } },
+          );
+          if (pr.ok) {
+            const { photoUri } = await pr.json();
+            if (photoUri) photos.push(photoUri);
+          }
+        } catch (_) {
+          // non-fatal — just skip this photo
+        }
+      }
+
+      const category = business.category || 'restaurant';
+      const services = MOCK_SERVICES[category] || MOCK_SERVICES.restaurant;
+
+      // Owner email: still guessed. Plug Hunter.io in here when the key exists.
+      const ownerIdx = Math.floor(Math.random() * MOCK_OWNERS.length);
+      const owner = MOCK_OWNERS[ownerIdx];
+
+      const enriched = {
+        ...business,
+        name: p.displayName?.text || business.name,
+        address: p.formattedAddress || business.address,
+        phone: p.nationalPhoneNumber || business.phone,
+        rating: p.rating ?? business.rating,
+        review_count: p.userRatingCount ?? business.review_count,
+        hours: Object.keys(hours).length ? hours : MOCK_HOURS,
+        services,
+        photos: photos.length
+          ? photos
+          : [
+              `https://picsum.photos/seed/${business.place_id}/800/600`,
+              `https://picsum.photos/seed/${business.place_id}2/800/600`,
+            ],
+        reviews: (p.reviews || []).slice(0, 3).map((r) => ({
+          author: r.authorAttribution?.displayName || 'Anonymous',
+          text: r.text?.text || '',
+          rating: r.rating || 0,
+        })),
+        editorial_summary: p.editorialSummary?.text,
+        owner_name: owner.name,
+        owner_email: owner.email, // TODO: replace with Hunter.io lookup
+        enriched: true,
+        enrichment_source: 'google_places_api',
+      };
+
+      this.log(`Enriched ${business.name} via Places API (${photos.length} photos)`, 'success');
+      this.completeTask();
+      return enriched;
+    } catch (err) {
+      this.logIssue(`Scraper API call failed for ${business.name}: ${err.message}`, 'warning');
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Hooks the four agents up to their actual APIs. Agents still fall back to the existing mock paths when keys aren't set, so nothing breaks in dev mode.

## What's wired

- **Scout** → Google Places (New) v1 Text Search. Filters out any listing with a `websiteUri` (that's our qualifier — they already have a site, skip). Paginates up to 3 pages per zip+category. Uses a tight field mask so we only pay for fields we use.
- **Scraper** → Google Places (New) v1 Place Details + Photos. Pulls real hours, phone, rating, reviews, up to 3 photos. Owner email is still a mock guess until we plug in Hunter.io.
- **Builder** → Anthropic SDK with **Claude Haiku 4.5**. Returns structured JSON (`{tagline, about}`) so no prose parsing. Falls back to the existing templates on error. ~\$0.001 per site.
- **Postman** → Real SendGrid `v3/mail/send` with open + click tracking. Needs `SENDGRID_FROM_EMAIL` on a domain with SPF + DKIM verified.

## New dep

Added `@anthropic-ai/sdk` to `dashboard/package.json`. Run `npm install` in `dashboard/` before booting.

## Env setup

Everything uses your existing `.env.example` keys — no new vars. Make sure these are set in `.env.local`:

\`\`\`
GOOGLE_MAPS_API_KEY=          # enables Scout + Scraper live mode
ANTHROPIC_API_KEY=            # enables Claude copy in Builder
SENDGRID_API_KEY=             # enables real email sending in Postman
SENDGRID_FROM_EMAIL=          # required for Postman; domain must have SPF + DKIM set up
\`\`\`

Without the keys set, agents behave exactly like before (mock mode).

## Cost control notes

- Google Places field masks cap per-request cost. Scout paginates max 3× per zip.
- Builder uses Haiku 4.5 (\$1/MTok input, \$5/MTok output) → ~\$0.001 per site.
- Scraper photos: max 3 per business, resolved via Places Photos API (~\$0.007 each).

## Test plan

- [ ] \`cd dashboard && npm install\`
- [ ] Boot with no keys set — confirm mock mode still works
- [ ] Add \`GOOGLE_MAPS_API_KEY\` — run Scout against a real zip, verify live results
- [ ] Add \`ANTHROPIC_API_KEY\` — generate a site, inspect the about paragraph (should sound human, not templated)
- [ ] Add \`SENDGRID_API_KEY\` + \`SENDGRID_FROM_EMAIL\` — send a pitch to yourself, verify delivery and tracking pixel loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)