### PR TITLE
Scout + Calendly pivot + hardening + Leads/Calls tabs + compliance

### DIFF
--- a/dashboard/client/src/App.jsx
+++ b/dashboard/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useWebSocket } from './hooks/useWebSocket.js';
 import Dashboard from './components/Dashboard.jsx';
 import Agents from './components/Agents.jsx';
+import Leads from './components/Leads.jsx';
 import ScheduledCalls from './components/ScheduledCalls.jsx';
 import Settings from './components/Settings.jsx';
 
@@ -40,6 +41,14 @@ export default function App() {
             🤖 Agents
           </button>
           <button
+            onClick={() => setPage('leads')}
+            className={`px-3 py-1.5 rounded text-sm transition ${
+              page === 'leads' ? 'bg-dark-600 text-white' : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            🗂 Leads
+          </button>
+          <button
             onClick={() => setPage('calls')}
             className={`px-3 py-1.5 rounded text-sm transition ${
               page === 'calls' ? 'bg-dark-600 text-white' : 'text-gray-400 hover:text-white'
@@ -68,6 +77,7 @@ export default function App() {
       {/* Main Content */}
       {page === 'dashboard' && <Dashboard ws={ws} />}
       {page === 'agents' && <Agents ws={ws} />}
+      {page === 'leads' && <Leads />}
       {page === 'calls' && <ScheduledCalls ws={ws} />}
       {page === 'settings' && <Settings />}
     </div>

--- a/dashboard/client/src/App.jsx
+++ b/dashboard/client/src/App.jsx
@@ -1,14 +1,27 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useWebSocket } from './hooks/useWebSocket.js';
 import Dashboard from './components/Dashboard.jsx';
 import Agents from './components/Agents.jsx';
 import Leads from './components/Leads.jsx';
 import ScheduledCalls from './components/ScheduledCalls.jsx';
 import Settings from './components/Settings.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
+
+const PAGE_TITLES = {
+  dashboard: 'Dashboard · Website Scaler',
+  agents: 'Agents · Website Scaler',
+  leads: 'Leads · Website Scaler',
+  calls: 'Scheduled Calls · Website Scaler',
+  settings: 'Settings · Website Scaler',
+};
 
 export default function App() {
   const [page, setPage] = useState('dashboard');
   const ws = useWebSocket();
+
+  useEffect(() => {
+    document.title = PAGE_TITLES[page] || 'Website Scaler';
+  }, [page]);
 
   return (
     <div className="min-h-screen bg-dark-900">
@@ -75,11 +88,13 @@ export default function App() {
       </nav>
 
       {/* Main Content */}
-      {page === 'dashboard' && <Dashboard ws={ws} />}
-      {page === 'agents' && <Agents ws={ws} />}
-      {page === 'leads' && <Leads />}
-      {page === 'calls' && <ScheduledCalls ws={ws} />}
-      {page === 'settings' && <Settings />}
+      <ErrorBoundary key={page}>
+        {page === 'dashboard' && <Dashboard ws={ws} />}
+        {page === 'agents' && <Agents ws={ws} />}
+        {page === 'leads' && <Leads />}
+        {page === 'calls' && <ScheduledCalls ws={ws} />}
+        {page === 'settings' && <Settings />}
+      </ErrorBoundary>
     </div>
   );
 }

--- a/dashboard/client/src/App.jsx
+++ b/dashboard/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useWebSocket } from './hooks/useWebSocket.js';
 import Dashboard from './components/Dashboard.jsx';
 import Agents from './components/Agents.jsx';
+import ScheduledCalls from './components/ScheduledCalls.jsx';
 import Settings from './components/Settings.jsx';
 
 export default function App() {
@@ -39,6 +40,14 @@ export default function App() {
             🤖 Agents
           </button>
           <button
+            onClick={() => setPage('calls')}
+            className={`px-3 py-1.5 rounded text-sm transition ${
+              page === 'calls' ? 'bg-dark-600 text-white' : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            📅 Calls
+          </button>
+          <button
             onClick={() => setPage('settings')}
             className={`px-3 py-1.5 rounded text-sm transition ${
               page === 'settings' ? 'bg-dark-600 text-white' : 'text-gray-400 hover:text-white'
@@ -59,6 +68,7 @@ export default function App() {
       {/* Main Content */}
       {page === 'dashboard' && <Dashboard ws={ws} />}
       {page === 'agents' && <Agents ws={ws} />}
+      {page === 'calls' && <ScheduledCalls ws={ws} />}
       {page === 'settings' && <Settings />}
     </div>
   );

--- a/dashboard/client/src/components/ErrorBoundary.jsx
+++ b/dashboard/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,38 @@
+import { Component } from 'react';
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="max-w-xl mx-auto mt-16 p-8 bg-dark-800 border border-red-500/40 rounded-lg text-center">
+        <div className="text-4xl mb-3">⚠️</div>
+        <div className="text-lg text-white mb-2">Something went wrong</div>
+        <div className="text-sm text-gray-400 mb-5 font-mono break-all">
+          {String(this.state.error?.message || this.state.error)}
+        </div>
+        <button
+          onClick={this.reset}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded"
+        >
+          Reload view
+        </button>
+      </div>
+    );
+  }
+}

--- a/dashboard/client/src/components/Leads.jsx
+++ b/dashboard/client/src/components/Leads.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+
+const STATUS_COLOR = {
+  discovered:  'bg-gray-500/20 text-gray-300 border-gray-500/30',
+  scraped:     'bg-blue-500/20 text-blue-300 border-blue-500/30',
+  pitched:     'bg-purple-500/20 text-purple-300 border-purple-500/30',
+  scheduled:   'bg-amber-500/20 text-amber-300 border-amber-500/30',
+  demo_built:  'bg-green-500/20 text-green-300 border-green-500/30',
+  site_built:  'bg-green-500/20 text-green-300 border-green-500/30',
+  completed:   'bg-gray-500/20 text-gray-300 border-gray-500/30',
+};
+
+export default function Leads() {
+  const [rows, setRows] = useState([]);
+  const [facets, setFacets] = useState({ zips: [], categories: [], statuses: [] });
+  const [q, setQ] = useState('');
+  const [zip, setZip] = useState('');
+  const [category, setCategory] = useState('');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  async function fetchLeads() {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (zip) params.set('zip', zip);
+    if (category) params.set('category', category);
+    if (status) params.set('status', status);
+    params.set('limit', '200');
+    const res = await fetch(`/api/businesses?${params.toString()}`);
+    const data = await res.json();
+    setRows(Array.isArray(data?.businesses) ? data.businesses : []);
+    if (data?.facets) setFacets(data.facets);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    fetchLeads();
+  }, [zip, category, status]);
+
+  // Debounce search
+  useEffect(() => {
+    const t = setTimeout(fetchLeads, 300);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  const reset = () => { setQ(''); setZip(''); setCategory(''); setStatus(''); };
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold text-white">Leads</h1>
+        <div className="text-sm text-gray-400">{rows.length} shown</div>
+      </div>
+
+      <div className="bg-dark-800 border border-dark-500 rounded-lg p-3 mb-4 flex flex-wrap gap-2 items-center">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search name, address, phone…"
+          className="flex-1 min-w-[200px] bg-dark-900 border border-dark-500 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+        <select value={zip} onChange={(e) => setZip(e.target.value)} className="bg-dark-900 border border-dark-500 rounded px-2 py-1.5 text-sm text-white">
+          <option value="">All zips</option>
+          {facets.zips.map((z) => <option key={z} value={z}>{z}</option>)}
+        </select>
+        <select value={category} onChange={(e) => setCategory(e.target.value)} className="bg-dark-900 border border-dark-500 rounded px-2 py-1.5 text-sm text-white">
+          <option value="">All categories</option>
+          {facets.categories.map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <select value={status} onChange={(e) => setStatus(e.target.value)} className="bg-dark-900 border border-dark-500 rounded px-2 py-1.5 text-sm text-white">
+          <option value="">All statuses</option>
+          {facets.statuses.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <button onClick={reset} className="text-sm text-gray-400 hover:text-white px-2">Reset</button>
+      </div>
+
+      {loading ? (
+        <div className="text-gray-400 p-8">Loading…</div>
+      ) : rows.length === 0 ? (
+        <div className="text-center text-gray-400 p-12 bg-dark-800 border border-dark-500 rounded-lg">No leads match these filters.</div>
+      ) : (
+        <div className="overflow-x-auto bg-dark-800 border border-dark-500 rounded-lg">
+          <table className="w-full text-sm">
+            <thead className="text-gray-400 text-xs uppercase bg-dark-900/40">
+              <tr>
+                <th className="text-left p-3">Business</th>
+                <th className="text-left p-3">Category</th>
+                <th className="text-left p-3">Zip</th>
+                <th className="text-right p-3">Rating</th>
+                <th className="text-right p-3">Reviews</th>
+                <th className="text-left p-3">Status</th>
+                <th className="text-left p-3">Owner email</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-dark-700 hover:bg-dark-700/30">
+                  <td className="p-3">
+                    <div className="text-white font-medium">{r.name}</div>
+                    <div className="text-xs text-gray-500 truncate max-w-xs">{r.address}</div>
+                  </td>
+                  <td className="p-3 text-gray-300">{r.category || '—'}</td>
+                  <td className="p-3 text-gray-300">{r.zip_code || '—'}</td>
+                  <td className="p-3 text-right text-gray-300">{r.rating ? r.rating.toFixed(1) : '—'}</td>
+                  <td className="p-3 text-right text-gray-300">{r.review_count ?? '—'}</td>
+                  <td className="p-3">
+                    <span className={`text-xs px-2 py-0.5 rounded border ${STATUS_COLOR[r.status] || 'bg-gray-500/20 text-gray-300 border-gray-500/30'}`}>
+                      {r.status || 'unknown'}
+                    </span>
+                  </td>
+                  <td className="p-3 text-gray-400 text-xs truncate max-w-[220px]">{r.owner_email || ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/client/src/components/ScheduledCalls.jsx
+++ b/dashboard/client/src/components/ScheduledCalls.jsx
@@ -9,6 +9,14 @@ const STATUS_STYLES = {
   no_show:      { label: 'No show',      color: 'bg-amber-500/20 text-amber-300 border-amber-500/30' },
 };
 
+const OUTCOMES = [
+  { key: '', label: '—' },
+  { key: 'won', label: 'Won' },
+  { key: 'lost', label: 'Lost' },
+  { key: 'follow_up', label: 'Follow-up' },
+  { key: 'no_show', label: 'No-show' },
+];
+
 function formatDateTime(iso) {
   if (!iso) return 'TBD';
   const d = new Date(iso);
@@ -78,6 +86,15 @@ export default function ScheduledCalls({ ws }) {
     } finally {
       setBuildingId(null);
     }
+  }
+
+  async function patchCall(id, patch) {
+    await fetch(`/api/scheduled-calls/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    fetchCalls();
   }
 
   if (loading) {
@@ -170,7 +187,34 @@ export default function ScheduledCalls({ ws }) {
                       {buildingId === call.id ? 'Rebuilding…' : 'Rebuild'}
                     </button>
                   )}
+                  <a
+                    href={`/api/scheduled-calls/${call.id}/ics`}
+                    className="text-xs text-gray-500 hover:text-gray-300"
+                  >
+                    Add to calendar
+                  </a>
                 </div>
+              </div>
+
+              <div className="mt-3 pt-3 border-t border-dark-700 flex flex-wrap gap-3 items-center">
+                <label className="text-xs text-gray-500 flex items-center gap-2">
+                  Outcome
+                  <select
+                    value={call.outcome || ''}
+                    onChange={(e) => patchCall(call.id, { outcome: e.target.value })}
+                    className="bg-dark-900 border border-dark-500 rounded px-2 py-1 text-xs text-white"
+                  >
+                    {OUTCOMES.map((o) => <option key={o.key} value={o.key}>{o.label}</option>)}
+                  </select>
+                </label>
+                <input
+                  defaultValue={call.notes || ''}
+                  onBlur={(e) => {
+                    if (e.target.value !== (call.notes || '')) patchCall(call.id, { notes: e.target.value });
+                  }}
+                  placeholder="Notes (save on blur)…"
+                  className="flex-1 min-w-[200px] bg-dark-900 border border-dark-500 rounded px-2 py-1 text-xs text-white placeholder-gray-500"
+                />
               </div>
             </div>
           );

--- a/dashboard/client/src/components/ScheduledCalls.jsx
+++ b/dashboard/client/src/components/ScheduledCalls.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+
+const STATUS_STYLES = {
+  scheduled:    { label: 'Scheduled',    color: 'bg-blue-500/20 text-blue-300 border-blue-500/30' },
+  demo_built:   { label: 'Demo ready',   color: 'bg-green-500/20 text-green-300 border-green-500/30' },
+  demo_failed:  { label: 'Build failed', color: 'bg-red-500/20 text-red-300 border-red-500/30' },
+  completed:    { label: 'Completed',    color: 'bg-gray-500/20 text-gray-300 border-gray-500/30' },
+  cancelled:    { label: 'Cancelled',    color: 'bg-gray-500/20 text-gray-500 border-gray-500/30' },
+  no_show:      { label: 'No show',      color: 'bg-amber-500/20 text-amber-300 border-amber-500/30' },
+};
+
+function formatDateTime(iso) {
+  if (!iso) return 'TBD';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short', month: 'short', day: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  });
+}
+
+function relativeTime(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const diffMs = d.getTime() - Date.now();
+  const diffMin = Math.round(diffMs / 60000);
+  const abs = Math.abs(diffMin);
+  const future = diffMin >= 0;
+  if (abs < 60) return future ? `in ${abs}m` : `${abs}m ago`;
+  const hours = Math.round(abs / 60);
+  if (hours < 24) return future ? `in ${hours}h` : `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return future ? `in ${days}d` : `${days}d ago`;
+}
+
+export default function ScheduledCalls({ ws }) {
+  const [calls, setCalls] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [buildingId, setBuildingId] = useState(null);
+
+  async function fetchCalls() {
+    try {
+      const res = await fetch('/api/scheduled-calls');
+      const data = await res.json();
+      setCalls(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.warn('Failed to fetch scheduled calls:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchCalls();
+    const interval = setInterval(fetchCalls, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!ws) return;
+    const unsubs = [
+      ws.on('demo_build_started', fetchCalls),
+      ws.on('demo_build_completed', fetchCalls),
+    ];
+    return () => unsubs.forEach((u) => u && u());
+  }, [ws]);
+
+  async function buildDemo(call) {
+    setBuildingId(call.id);
+    try {
+      const res = await fetch(`/api/scheduled-calls/${call.id}/build-demo`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Build failed');
+      await fetchCalls();
+    } catch (err) {
+      alert(`Build failed: ${err.message}`);
+    } finally {
+      setBuildingId(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-gray-400">Loading scheduled calls…</div>;
+  }
+
+  if (calls.length === 0) {
+    return (
+      <div className="p-10 text-center">
+        <div className="text-4xl mb-3">📅</div>
+        <div className="text-lg text-white mb-1">No calls scheduled yet</div>
+        <div className="text-sm text-gray-400">
+          When a prospect books via Calendly, they'll appear here and the demo site
+          will be built automatically.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-2xl font-semibold text-white">Scheduled Calls</h1>
+        <div className="text-sm text-gray-400">{calls.length} upcoming</div>
+      </div>
+
+      <div className="space-y-3">
+        {calls.map((call) => {
+          const status = STATUS_STYLES[call.status] || STATUS_STYLES.scheduled;
+          const hasDemo = !!call.preview_url;
+          return (
+            <div
+              key={call.id}
+              className="bg-dark-800 border border-dark-500 rounded-lg p-4 hover:border-dark-400 transition"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <div className="text-white font-semibold truncate">
+                      {call.business_name || 'Unknown business'}
+                    </div>
+                    <span className={`text-xs px-2 py-0.5 rounded border ${status.color}`}>
+                      {status.label}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-400 mb-2">
+                    {call.category ? `${call.category} • ` : ''}
+                    {call.address || 'Address unknown'}
+                  </div>
+                  <div className="flex items-center gap-4 text-sm">
+                    <div className="text-gray-300">
+                      <span className="text-gray-500">When:</span>{' '}
+                      {formatDateTime(call.scheduled_at)}{' '}
+                      <span className="text-gray-500">({relativeTime(call.scheduled_at)})</span>
+                    </div>
+                    {call.booker_email && (
+                      <div className="text-gray-400 truncate">
+                        <span className="text-gray-500">Booked by:</span>{' '}
+                        {call.booker_name || call.booker_email}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col items-end gap-2 shrink-0">
+                  {hasDemo ? (
+                    <a
+                      href={call.preview_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition"
+                    >
+                      Open demo →
+                    </a>
+                  ) : (
+                    <button
+                      disabled={buildingId === call.id}
+                      onClick={() => buildDemo(call)}
+                      className="px-3 py-1.5 bg-dark-600 hover:bg-dark-500 disabled:opacity-50 text-white text-sm rounded transition"
+                    >
+                      {buildingId === call.id ? 'Building…' : 'Build demo'}
+                    </button>
+                  )}
+                  {hasDemo && (
+                    <button
+                      disabled={buildingId === call.id}
+                      onClick={() => buildDemo(call)}
+                      className="text-xs text-gray-500 hover:text-gray-300"
+                    >
+                      {buildingId === call.id ? 'Rebuilding…' : 'Rebuild'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/client/src/components/Settings.jsx
+++ b/dashboard/client/src/components/Settings.jsx
@@ -24,6 +24,26 @@ const SETTING_GROUPS = [
     ],
   },
   {
+    title: 'Call Booking (Calendly)',
+    fields: [
+      { key: 'calendly_link', label: 'Calendly Link', type: 'text', placeholder: 'https://calendly.com/you/15min' },
+      { key: 'calendly_webhook_secret', label: 'Webhook Secret', type: 'password', placeholder: 'Used to sign unsubscribe tokens' },
+    ],
+  },
+  {
+    title: 'Compliance',
+    fields: [
+      { key: 'sender_physical_address', label: 'Sender Physical Address (CAN-SPAM)', type: 'text', placeholder: '123 Main St, City, ST 12345' },
+      { key: 'unsubscribe_base_url', label: 'Unsubscribe Base URL', type: 'text', placeholder: 'https://yourapp.example.com' },
+    ],
+  },
+  {
+    title: 'Lead Quality',
+    fields: [
+      { key: 'min_review_count', label: 'Minimum Review Count', type: 'number', placeholder: '5' },
+    ],
+  },
+  {
     title: 'Limits & Configuration',
     fields: [
       { key: 'daily_token_limit', label: 'Daily Token Limit', type: 'number' },

--- a/dashboard/client/src/components/Settings.jsx
+++ b/dashboard/client/src/components/Settings.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import SuppressionsPanel from './SuppressionsPanel.jsx';
 
 const SETTING_GROUPS = [
   {
@@ -168,6 +169,8 @@ export default function Settings() {
           </div>
         </div>
       ))}
+
+      <SuppressionsPanel />
 
       <div className="card border-dark-500">
         <div className="card-header mb-2">How It Works</div>

--- a/dashboard/client/src/components/SuppressionsPanel.jsx
+++ b/dashboard/client/src/components/SuppressionsPanel.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+
+export default function SuppressionsPanel() {
+  const [rows, setRows] = useState([]);
+  const [email, setEmail] = useState('');
+  const [reason, setReason] = useState('');
+
+  async function refresh() {
+    try {
+      const res = await fetch('/api/suppressions');
+      const data = await res.json();
+      setRows(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => { refresh(); }, []);
+
+  async function add(e) {
+    e.preventDefault();
+    if (!email) return;
+    await fetch('/api/suppressions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, reason }),
+    });
+    setEmail(''); setReason('');
+    refresh();
+  }
+
+  async function remove(addr) {
+    if (!confirm(`Remove ${addr} from suppression list?`)) return;
+    await fetch(`/api/suppressions/${encodeURIComponent(addr)}`, { method: 'DELETE' });
+    refresh();
+  }
+
+  return (
+    <div className="card">
+      <div className="card-header mb-3">Email Suppressions</div>
+      <form onSubmit={add} className="flex flex-wrap gap-2 mb-3">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="address@example.com"
+          className="flex-1 min-w-[200px] bg-dark-800 border border-dark-500 rounded px-3 py-1.5 text-sm text-white"
+        />
+        <input
+          type="text"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Reason (optional)"
+          className="flex-1 min-w-[150px] bg-dark-800 border border-dark-500 rounded px-3 py-1.5 text-sm text-white"
+        />
+        <button className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded">Add</button>
+      </form>
+      {rows.length === 0 ? (
+        <div className="text-sm text-gray-400">No suppressed addresses.</div>
+      ) : (
+        <div className="overflow-x-auto max-h-64 overflow-y-auto">
+          <table className="w-full text-sm">
+            <thead className="text-gray-400 text-xs uppercase">
+              <tr>
+                <th className="text-left p-2">Email</th>
+                <th className="text-left p-2">Reason</th>
+                <th className="text-left p-2">Source</th>
+                <th className="text-right p-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-dark-700">
+                  <td className="p-2 text-white">{r.email}</td>
+                  <td className="p-2 text-gray-400">{r.reason || '—'}</td>
+                  <td className="p-2 text-gray-500 text-xs">{r.source || '—'}</td>
+                  <td className="p-2 text-right">
+                    <button
+                      onClick={() => remove(r.email)}
+                      className="text-xs text-gray-400 hover:text-red-400"
+                    >Remove</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/server/agents/Accountant.js
+++ b/dashboard/server/agents/Accountant.js
@@ -1,13 +1,35 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getDb, getSetting } from '../database.js';
 
-// Approximate cost per 1K tokens by model
+// Approximate cost per 1K tokens by model.
+// `input`/`output` for standard tokens; `cacheWrite`/`cacheRead` for prompt-cache.
 const COST_PER_1K = {
-  'claude-sonnet-4-6': 0.003,
-  'gpt-4o': 0.005,
-  'gpt-4o-mini': 0.00015,
-  default: 0.003,
+  'claude-sonnet-4-6': { input: 0.003, output: 0.015, cacheWrite: 0.00375, cacheRead: 0.0003 },
+  'claude-haiku-4-5':  { input: 0.001, output: 0.005, cacheWrite: 0.00125, cacheRead: 0.0001 },
+  'gpt-4o':            { input: 0.005, output: 0.015, cacheWrite: 0.005,   cacheRead: 0.0025 },
+  'gpt-4o-mini':       { input: 0.00015, output: 0.0006, cacheWrite: 0.00015, cacheRead: 0.000075 },
+  default:             { input: 0.003, output: 0.015, cacheWrite: 0.00375, cacheRead: 0.0003 },
 };
+
+// Cost a token-usage record. `usage` is either a scalar (legacy approximate
+// count) or a Claude `response.usage` object with input/output/cache fields.
+function costTokens(usage, model) {
+  const p = COST_PER_1K[model] || COST_PER_1K.default;
+  if (typeof usage === 'number') {
+    // Legacy path: treat as output-equivalent tokens.
+    return { tokens: usage, cost: (usage / 1000) * p.output };
+  }
+  const input = usage.input_tokens || 0;
+  const output = usage.output_tokens || 0;
+  const cacheWrite = usage.cache_creation_input_tokens || 0;
+  const cacheRead = usage.cache_read_input_tokens || 0;
+  const cost =
+    (input / 1000) * p.input +
+    (output / 1000) * p.output +
+    (cacheWrite / 1000) * p.cacheWrite +
+    (cacheRead / 1000) * p.cacheRead;
+  return { tokens: input + output + cacheWrite + cacheRead, cost };
+}
 
 export class Accountant extends BaseAgent {
   constructor(broadcast) {
@@ -26,11 +48,15 @@ export class Accountant extends BaseAgent {
     await super.stop();
   }
 
-  trackUsage(agentName, tokens, model = 'default') {
-    const db = getDb();
-    const costPer1K = COST_PER_1K[model] || COST_PER_1K.default;
-    const cost = (tokens / 1000) * costPer1K;
+  // `usage` can be a scalar token count (legacy) or a Claude `response.usage`
+  // object. Skip zero-token records so Scout/Scraper/Postman don't spam the
+  // log when they don't call an LLM.
+  trackUsage(agentName, usage, model = 'default') {
+    if (!usage || (typeof usage === 'number' && usage === 0)) return;
+    const { tokens, cost } = costTokens(usage, model);
+    if (tokens === 0) return;
 
+    const db = getDb();
     db.prepare(
       'INSERT INTO token_usage (agent_name, tokens_used, cost_estimate, model) VALUES (?, ?, ?, ?)'
     ).run(agentName, tokens, cost, model);
@@ -39,6 +65,7 @@ export class Accountant extends BaseAgent {
       agent: agentName,
       tokens,
       cost,
+      model,
       timestamp: new Date().toISOString(),
     });
 

--- a/dashboard/server/agents/BaseAgent.js
+++ b/dashboard/server/agents/BaseAgent.js
@@ -38,6 +38,13 @@ export class BaseAgent {
       'INSERT INTO agent_logs (agent_name, action, status, message) VALUES (?, ?, ?, ?)'
     ).run(this.name, message, status, message);
 
+    // Structured stdout log — picked up by log shippers (CloudWatch, Loki,
+    // Datadog) and trivial to grep locally.
+    const level = status === 'error' ? 'error' : status === 'warning' ? 'warn' : 'info';
+    console.log(JSON.stringify({
+      level, ts: new Date().toISOString(), agent: this.name, status, message,
+    }));
+
     this.broadcast('activity', {
       agent: this.name,
       action: message,

--- a/dashboard/server/agents/Builder.js
+++ b/dashboard/server/agents/Builder.js
@@ -205,7 +205,14 @@ export class Builder extends BaseAgent {
   generateHtml(biz, design, about, tagline) {
     const services = Array.isArray(biz.services) ? biz.services : ['Quality Service'];
     const hours = biz.hours || {};
+    const reviews = Array.isArray(biz.reviews) ? biz.reviews.slice(0, 3) : [];
     const isDark = design.style === 'bold-electric';
+    const heroImg = Array.isArray(biz.photos) && biz.photos[0] ? biz.photos[0] : null;
+    const todayKey = new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+    const openStatus = this.computeOpenStatus(hours);
+    const jsonLd = this.buildJsonLd(biz, services, hours);
+    const metaDesc = this.escHtml(String(about).slice(0, 155));
+    const ogImage = heroImg ? this.escHtml(heroImg) : '';
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -213,6 +220,16 @@ export class Builder extends BaseAgent {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${this.escHtml(biz.name)}</title>
+  <meta name="description" content="${metaDesc}">
+  <meta name="theme-color" content="${design.primary}">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="${this.escHtml(biz.name)}">
+  <meta property="og:description" content="${metaDesc}">
+  ${ogImage ? `<meta property="og:image" content="${ogImage}">` : ''}
+  <meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}">
+  <meta name="twitter:title" content="${this.escHtml(biz.name)}">
+  <meta name="twitter:description" content="${metaDesc}">
+  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -273,6 +290,42 @@ export class Builder extends BaseAgent {
       border-bottom: 1px solid ${isDark ? '#333' : '#eee'};
     }
     .hours-table td:first-child { font-weight: 600; text-transform: capitalize; }
+    .hours-table tr.today td { background: ${design.primary}22; font-weight: 700; }
+    .status-badge {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-top: 10px;
+    }
+    .status-open { background: #10b98122; color: #065f46; }
+    .status-closed { background: #ef444422; color: #991b1b; }
+    .reviews-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 15px;
+      margin-top: 20px;
+    }
+    .review-card {
+      background: ${isDark ? '#0F3460' : '#fff'};
+      border-radius: 10px;
+      padding: 18px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .review-card .stars { color: #f59e0b; margin-bottom: 6px; }
+    .review-card .author { font-size: 0.9rem; font-weight: 600; margin-top: 10px; }
+    .cta-row { margin-top: 20px; text-align: center; }
+    .cta-btn {
+      display: inline-block;
+      padding: 12px 26px;
+      border-radius: 8px;
+      background: #fff;
+      color: ${design.primary};
+      text-decoration: none;
+      font-weight: 700;
+      margin: 4px;
+    }
     .map-section { background: ${isDark ? '#0F3460' : '#f9fafb'}; }
     .map-container {
       border-radius: 10px;
@@ -309,6 +362,11 @@ export class Builder extends BaseAgent {
       <h1>${this.escHtml(biz.name)}</h1>
       <p>${this.escHtml(tagline)}</p>
       ${biz.rating ? `<div class="rating">${'&#9733;'.repeat(Math.round(biz.rating))} ${biz.rating}/5 (${biz.review_count || 0} reviews)</div>` : ''}
+      ${openStatus ? `<div class="status-badge ${openStatus.open ? 'status-open' : 'status-closed'}">${openStatus.open ? 'Open now' : 'Closed now'}</div>` : ''}
+      <div class="cta-row">
+        ${biz.phone ? `<a class="cta-btn" href="tel:${this.escHtml(biz.phone)}">Call ${this.escHtml(biz.phone)}</a>` : ''}
+        ${biz.maps_url ? `<a class="cta-btn" href="${this.escHtml(biz.maps_url)}" target="_blank" rel="noopener noreferrer">Get directions</a>` : ''}
+      </div>
     </div>
   </section>
 
@@ -333,8 +391,26 @@ export class Builder extends BaseAgent {
     <div class="container">
       <h2>Hours</h2>
       <table class="hours-table">
-        ${Object.entries(hours).map(([day, time]) => `<tr><td>${this.escHtml(day)}</td><td>${this.escHtml(time)}</td></tr>`).join('\n        ')}
+        ${Object.entries(hours).map(([day, time]) => {
+          const isToday = day.toLowerCase() === todayKey;
+          return `<tr${isToday ? ' class="today"' : ''}><td>${this.escHtml(day)}</td><td>${this.escHtml(time)}</td></tr>`;
+        }).join('\n        ')}
       </table>
+    </div>
+  </section>` : ''}
+
+  ${reviews.length > 0 ? `
+  <section>
+    <div class="container">
+      <h2>What Customers Say</h2>
+      <div class="reviews-grid">
+        ${reviews.map((r) => `
+          <div class="review-card">
+            <div class="stars">${'&#9733;'.repeat(Math.max(0, Math.min(5, Math.round(r.rating || 0))))}</div>
+            <p>${this.escHtml(String(r.text || '').slice(0, 240))}</p>
+            <div class="author">— ${this.escHtml(r.author || 'Customer')}</div>
+          </div>`).join('\n        ')}
+      </div>
     </div>
   </section>` : ''}
 
@@ -343,7 +419,7 @@ export class Builder extends BaseAgent {
       <h2>Find Us</h2>
       <p style="text-align:center;">${this.escHtml(biz.address || '')}</p>
       <div class="map-container">
-        <iframe src="https://maps.google.com/maps?q=${encodeURIComponent(biz.address || biz.name)}&output=embed" allowfullscreen loading="lazy"></iframe>
+        <iframe src="https://maps.google.com/maps?q=${encodeURIComponent(biz.address || biz.name)}&output=embed" allowfullscreen loading="lazy" title="Map showing ${this.escHtml(biz.name)} location"></iframe>
       </div>
     </div>
   </section>
@@ -370,5 +446,77 @@ export class Builder extends BaseAgent {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
+  }
+
+  // Parse hours like "9:00 AM – 6:00 PM" and decide if we're open right now.
+  // Returns { open: bool } or null if we can't tell.
+  computeOpenStatus(hours) {
+    if (!hours || typeof hours !== 'object') return null;
+    const dayKey = new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+    const todaySpec = hours[dayKey];
+    if (!todaySpec || /closed/i.test(todaySpec)) return { open: false };
+
+    const match = String(todaySpec).match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?\s*[–\-to]+\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?/i);
+    if (!match) return null;
+    const [, h1, m1 = '0', ap1, h2, m2 = '0', ap2] = match;
+    const to24 = (h, m, ap) => {
+      let n = parseInt(h, 10);
+      if (ap) {
+        const up = ap.toUpperCase();
+        if (up === 'PM' && n !== 12) n += 12;
+        if (up === 'AM' && n === 12) n = 0;
+      }
+      return n * 60 + parseInt(m, 10);
+    };
+    const now = new Date();
+    const cur = now.getHours() * 60 + now.getMinutes();
+    const open = to24(h1, m1, ap1 || ap2);
+    const close = to24(h2, m2, ap2 || ap1);
+    return { open: cur >= open && cur <= close };
+  }
+
+  // schema.org LocalBusiness JSON-LD. Helps Google + social unfurls.
+  buildJsonLd(biz, services, hours) {
+    const weekdayMap = {
+      monday: 'Mo', tuesday: 'Tu', wednesday: 'We', thursday: 'Th',
+      friday: 'Fr', saturday: 'Sa', sunday: 'Su',
+    };
+    const openingHours = Object.entries(hours || {})
+      .map(([day, spec]) => {
+        if (/closed/i.test(spec)) return null;
+        const m = String(spec).match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?\s*[–\-to]+\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?/i);
+        if (!m || !weekdayMap[day.toLowerCase()]) return null;
+        const fmt = (h, mn, ap) => {
+          let n = parseInt(h, 10);
+          if (ap) {
+            const up = ap.toUpperCase();
+            if (up === 'PM' && n !== 12) n += 12;
+            if (up === 'AM' && n === 12) n = 0;
+          }
+          return String(n).padStart(2, '0') + ':' + (mn || '00').padStart(2, '0');
+        };
+        return `${weekdayMap[day.toLowerCase()]} ${fmt(m[1], m[2], m[3] || m[6])}-${fmt(m[4], m[5], m[6] || m[3])}`;
+      })
+      .filter(Boolean);
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'LocalBusiness',
+      name: biz.name,
+      address: biz.address || undefined,
+      telephone: biz.phone || undefined,
+      image: Array.isArray(biz.photos) && biz.photos.length ? biz.photos : undefined,
+      geo: biz.latitude && biz.longitude
+        ? { '@type': 'GeoCoordinates', latitude: biz.latitude, longitude: biz.longitude }
+        : undefined,
+      aggregateRating: biz.rating
+        ? { '@type': 'AggregateRating', ratingValue: biz.rating, reviewCount: biz.review_count || 0 }
+        : undefined,
+      priceRange: biz.price_range || undefined,
+      openingHours: openingHours.length ? openingHours : undefined,
+      hasOfferCatalog: services?.length
+        ? { '@type': 'OfferCatalog', name: 'Services', itemListElement: services.map((s) => ({ '@type': 'Offer', itemOffered: { '@type': 'Service', name: s } })) }
+        : undefined,
+    };
   }
 }

--- a/dashboard/server/agents/Builder.js
+++ b/dashboard/server/agents/Builder.js
@@ -215,6 +215,7 @@ export class Builder extends BaseAgent {
     const ogImage = heroImg ? this.escHtml(heroImg) : '';
 
     return `<!DOCTYPE html>
+<!-- built-at: ${new Date().toISOString()} | business: ${biz.place_id || biz.id} -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -229,6 +230,7 @@ export class Builder extends BaseAgent {
   <meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}">
   <meta name="twitter:title" content="${this.escHtml(biz.name)}">
   <meta name="twitter:description" content="${metaDesc}">
+  <link rel="canonical" href="${this.escHtml(biz.maps_url || '#')}">
   <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -326,6 +328,19 @@ export class Builder extends BaseAgent {
       font-weight: 700;
       margin: 4px;
     }
+    .gallery {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 12px;
+      margin-top: 20px;
+    }
+    .gallery img {
+      width: 100%;
+      height: 200px;
+      object-fit: cover;
+      border-radius: 10px;
+      display: block;
+    }
     .map-section { background: ${isDark ? '#0F3460' : '#f9fafb'}; }
     .map-container {
       border-radius: 10px;
@@ -396,6 +411,16 @@ export class Builder extends BaseAgent {
           return `<tr${isToday ? ' class="today"' : ''}><td>${this.escHtml(day)}</td><td>${this.escHtml(time)}</td></tr>`;
         }).join('\n        ')}
       </table>
+    </div>
+  </section>` : ''}
+
+  ${Array.isArray(biz.photos) && biz.photos.length > 0 ? `
+  <section>
+    <div class="container">
+      <h2>Gallery</h2>
+      <div class="gallery">
+        ${biz.photos.slice(0, 6).map((src, i) => `<img src="${this.escHtml(src)}" alt="${this.escHtml(biz.name)} photo ${i + 1}" loading="lazy" decoding="async">`).join('\n        ')}
+      </div>
     </div>
   </section>` : ''}
 

--- a/dashboard/server/agents/Builder.js
+++ b/dashboard/server/agents/Builder.js
@@ -84,9 +84,11 @@ export class Builder extends BaseAgent {
     const anthropicKey = getSetting('anthropic_api_key');
     let about;
     let tagline;
+    let usage = null;
+    let model = null;
     if (anthropicKey) {
       try {
-        ({ about, tagline } = await this.generateCopyWithClaude(business, anthropicKey));
+        ({ about, tagline, usage, model } = await this.generateCopyWithClaude(business, anthropicKey));
       } catch (err) {
         this.log(`Claude copy failed (${err.message}) — falling back to templates`, 'warning');
         about = this.generateAbout(business);
@@ -119,11 +121,15 @@ export class Builder extends BaseAgent {
       previewUrl,
       buildTime,
       designStyle: design.style,
+      usage,
+      model,
     };
   }
 
   // Real Claude copy generation. Haiku for minimum token cost (~$0.001 per site).
-  // Returns { about, tagline } — structured JSON so we never have to parse prose.
+  // Returns { about, tagline, usage, model }. `cache_control` on the system
+  // block activates prompt caching once the system prompt crosses Haiku's
+  // 2048-token threshold — a no-op until then, and free to leave enabled.
   async generateCopyWithClaude(biz, apiKey) {
     const client = new Anthropic({ apiKey });
     const reviews = Array.isArray(biz.reviews)
@@ -143,14 +149,21 @@ export class Builder extends BaseAgent {
       .filter(Boolean)
       .join('\n');
 
+    const model = 'claude-haiku-4-5';
     const response = await client.messages.create({
-      model: 'claude-haiku-4-5',
+      model,
       max_tokens: 400,
-      system:
-        'You write short, grounded website copy for small local businesses. ' +
-        'No jargon, no marketing clichés ("dedicated to", "nestled", "where quality meets"). ' +
-        'Base every line on the business data provided; never invent credentials or services. ' +
-        'Return ONLY valid JSON matching: {"tagline": "5-9 word phrase", "about": "50-90 word paragraph (2-3 sentences)"}',
+      system: [
+        {
+          type: 'text',
+          text:
+            'You write short, grounded website copy for small local businesses. ' +
+            'No jargon, no marketing clichés ("dedicated to", "nestled", "where quality meets"). ' +
+            'Base every line on the business data provided; never invent credentials or services. ' +
+            'Return ONLY valid JSON matching: {"tagline": "5-9 word phrase", "about": "50-90 word paragraph (2-3 sentences)"}',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
       messages: [{ role: 'user', content: userInput }],
     });
 
@@ -162,7 +175,7 @@ export class Builder extends BaseAgent {
     if (!parsed.about || !parsed.tagline) {
       throw new Error('Claude returned incomplete copy JSON');
     }
-    return { about: parsed.about, tagline: parsed.tagline };
+    return { about: parsed.about, tagline: parsed.tagline, usage: response.usage, model };
   }
 
   generateAbout(biz) {

--- a/dashboard/server/agents/Builder.js
+++ b/dashboard/server/agents/Builder.js
@@ -231,7 +231,7 @@ export class Builder extends BaseAgent {
   <meta name="twitter:title" content="${this.escHtml(biz.name)}">
   <meta name="twitter:description" content="${metaDesc}">
   <link rel="canonical" href="${this.escHtml(biz.maps_url || '#')}">
-  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+  <script type="application/ld+json">${this.safeJsonForScript(jsonLd)}</script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -471,6 +471,17 @@ export class Builder extends BaseAgent {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
+  }
+
+  // JSON.stringify doesn't escape `</` — so a business named with a literal
+  // `</script>` inside would break out of the JSON-LD block. Replace `<`,
+  // `>`, and the U+2028/2029 line separators that break some parsers.
+  safeJsonForScript(obj) {
+    return JSON.stringify(obj)
+      .replace(/</g, '\\u003c')
+      .replace(/>/g, '\\u003e')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029');
   }
 
   // Parse hours like "9:00 AM – 6:00 PM" and decide if we're open right now.

--- a/dashboard/server/agents/Postman.js
+++ b/dashboard/server/agents/Postman.js
@@ -1,21 +1,23 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getDb, getSetting } from '../database.js';
 
+// Templates pitch a 15-min call. We build the demo *after* the call is booked
+// (via Calendly webhook). The `url` argument is the user's Calendly link.
 const EMAIL_TEMPLATES = [
   {
-    subject: (name) => `I built a website for ${name} — take a look!`,
+    subject: (name) => `Quick idea for ${name} — 15 min?`,
     body: (biz, url) =>
-      `Hi ${biz.owner_name || 'there'},\n\nI came across ${biz.name} on Google and was really impressed — ${biz.rating} stars with ${biz.review_count} reviews is incredible!\n\nI noticed you don't have a website yet, so I went ahead and built one for you. Here's a preview:\n\n${url}\n\nIf you like it, it's yours for just $50 — no contracts, no subscriptions, you own it forever.\n\nJust reply to this email and I'll get it set up on your domain.\n\nBest,\nWebsite Scaler Team`,
+      `Hi ${biz.owner_name || 'there'},\n\nI came across ${biz.name} on Google — ${biz.rating} stars with ${biz.review_count} reviews is genuinely impressive.\n\nI noticed you don't have a website yet. I'd love to jump on a quick 15-minute call and show you a custom demo I can put together for your business. No pitch deck, no pressure — just a preview of what it could look like.\n\nBook a time here: ${url}\n\nIf the timing's off, reply and I'll work around your schedule.\n\nBest,\nWebsite Scaler Team`,
   },
   {
-    subject: (name) => `${name} deserves a great website — here's one I made for you`,
+    subject: (name) => `${name} deserves a great website — let's talk`,
     body: (biz, url) =>
-      `Hey ${biz.owner_name || 'there'},\n\nYour ${biz.review_count} Google reviews speak volumes about ${biz.name}. Your customers clearly love what you do!\n\nI put together a professional website for your business — completely free to preview:\n\n${url}\n\nIt's mobile-friendly, fast, and showcases your services beautifully. If you want it, just $50 and it's yours. No monthly fees, ever.\n\nWant it? Just hit reply.\n\nCheers,\nWebsite Scaler Team`,
+      `Hey ${biz.owner_name || 'there'},\n\nYour ${biz.review_count} Google reviews speak for themselves — clearly ${biz.name} is doing something right.\n\nI help small businesses get online without the monthly-fee nonsense. Got 15 minutes this week? I'll have a custom demo of a site for you, ready to look at together.\n\nGrab any time that works: ${url}\n\nCheers,\nWebsite Scaler Team`,
   },
   {
-    subject: (name) => `Quick question about ${name}`,
+    subject: (name) => `Free demo site for ${name}?`,
     body: (biz, url) =>
-      `Hi ${biz.owner_name || 'there'},\n\nI was looking up ${biz.category || 'businesses'} in your area and found ${biz.name}. Love the ${biz.rating}-star rating!\n\nI build websites for small businesses, and I actually made one for you already — here's the preview:\n\n${url}\n\nIf it looks good, you can claim it for $50. That's it — one payment, you own the site outright.\n\nNo pressure at all. Just thought you'd want to see it!\n\nBest regards,\nWebsite Scaler Team`,
+      `Hi ${biz.owner_name || 'there'},\n\nI build websites for local ${biz.category || 'businesses'}, and ${biz.name} caught my eye — ${biz.rating} stars doesn't happen by accident.\n\nI'd like to put together a free demo site for you and walk you through it on a 15-minute call. No slides, no hard sell — if you like it, we talk numbers. If not, no hard feelings.\n\nPick a slot: ${url}\n\nBest regards,\nWebsite Scaler Team`,
   },
 ];
 
@@ -41,10 +43,12 @@ export class Postman extends BaseAgent {
       await new Promise((r) => setTimeout(r, 5000));
     }
 
-    // Pick random template (in real implementation, use LLM)
+    // `previewUrl` is the Calendly link today. The demo site is built *after*
+    // the call is booked (via the Calendly webhook), not up front.
+    const calendlyLink = previewUrl || getSetting('calendly_link') || '';
     const template = EMAIL_TEMPLATES[Math.floor(Math.random() * EMAIL_TEMPLATES.length)];
     const subject = template.subject(business.name);
-    const body = template.body(business, previewUrl);
+    const body = template.body(business, calendlyLink);
 
     const apiKey = getSetting('sendgrid_api_key');
 

--- a/dashboard/server/agents/Postman.js
+++ b/dashboard/server/agents/Postman.js
@@ -39,6 +39,17 @@ export class Postman extends BaseAgent {
       return { suppressed: true, to: business.owner_email };
     }
 
+    // Generic role-account guard (contact@, info@, support@ ...). These
+    // rarely reach the owner and hurt sender reputation; skip by default,
+    // configurable via `suppress_generic_addresses` setting.
+    if (business.owner_email && getSetting('suppress_generic_addresses') !== '0') {
+      const local = String(business.owner_email).split('@')[0].toLowerCase();
+      if (/^(contact|info|hello|support|admin|office|sales|noreply|no-reply|team)$/.test(local)) {
+        this.log(`Skipping ${business.owner_email} — generic role account`, 'info');
+        return { skipped: 'generic', to: business.owner_email };
+      }
+    }
+
     // Rate limiting
     const maxPerHour = parseInt(getSetting('max_emails_per_hour')) || 50;
     if (Date.now() - this.hourResetTime > 3600000) {
@@ -54,7 +65,7 @@ export class Postman extends BaseAgent {
     // the call is booked (via the Calendly webhook), not up front.
     const calendlyLink = previewUrl || getSetting('calendly_link') || '';
     const template = EMAIL_TEMPLATES[Math.floor(Math.random() * EMAIL_TEMPLATES.length)];
-    const subject = template.subject(business.name);
+    const subject = this.normalizeSubject(template.subject(business.name));
     const bodyCore = template.body(business, calendlyLink);
 
     // CAN-SPAM footer: unsubscribe link + physical address are required.
@@ -163,6 +174,19 @@ export class Postman extends BaseAgent {
     } catch (err) {
       this.logIssue(`Email send failed for ${to}: ${err.message}`, 'error');
     }
+  }
+
+  // Subject quality guards — ALL-CAPS and overlong subjects correlate with
+  // spam classification. Cap at 60 chars, and detitle any ALL-CAPS run.
+  normalizeSubject(subject) {
+    let s = String(subject || '').trim();
+    // Drop trailing exclamation / question-mark pile-ups (!!!, ???).
+    s = s.replace(/([!?])\1+/g, '$1');
+    // De-shout any run of 4+ uppercase letters.
+    s = s.replace(/[A-Z]{4,}/g, (run) => run.charAt(0) + run.slice(1).toLowerCase());
+    // Clamp length for deliverability (Gmail truncates mid-word past ~70).
+    if (s.length > 60) s = s.slice(0, 57).replace(/\s+\S*$/, '') + '…';
+    return s;
   }
 
   // Minimal HTML renderer for the plaintext body. Escapes, then converts

--- a/dashboard/server/agents/Postman.js
+++ b/dashboard/server/agents/Postman.js
@@ -1,5 +1,6 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getDb, getSetting } from '../database.js';
+import crypto from 'crypto';
 
 // Templates pitch a 15-min call. We build the demo *after* the call is booked
 // (via Calendly webhook). The `url` argument is the user's Calendly link.
@@ -32,6 +33,12 @@ export class Postman extends BaseAgent {
   async sendPitch(business, previewUrl) {
     this.heartbeat();
 
+    // Suppression check — never send to a previously-unsubscribed address.
+    if (business.owner_email && this.isSuppressed(business.owner_email)) {
+      this.log(`Skipping ${business.owner_email} — on suppression list`, 'info');
+      return { suppressed: true, to: business.owner_email };
+    }
+
     // Rate limiting
     const maxPerHour = parseInt(getSetting('max_emails_per_hour')) || 50;
     if (Date.now() - this.hourResetTime > 3600000) {
@@ -48,12 +55,18 @@ export class Postman extends BaseAgent {
     const calendlyLink = previewUrl || getSetting('calendly_link') || '';
     const template = EMAIL_TEMPLATES[Math.floor(Math.random() * EMAIL_TEMPLATES.length)];
     const subject = template.subject(business.name);
-    const body = template.body(business, calendlyLink);
+    const bodyCore = template.body(business, calendlyLink);
+
+    // CAN-SPAM footer: unsubscribe link + physical address are required.
+    const unsubUrl = this.buildUnsubscribeUrl(business.owner_email);
+    const physical = getSetting('sender_physical_address') || '';
+    const footerText = `\n\n---\nYou're receiving this because we found ${business.name} on Google Maps. If you'd rather not hear from us, unsubscribe here: ${unsubUrl}${physical ? `\n${physical}` : ''}`;
+    const body = bodyCore + footerText;
 
     const apiKey = getSetting('sendgrid_api_key');
 
     if (apiKey) {
-      await this.sendViaApi(business.owner_email, subject, body, apiKey);
+      await this.sendViaApi(business.owner_email, subject, body, apiKey, { unsubUrl });
     } else {
       // Mock mode
       await new Promise((r) => setTimeout(r, Math.random() * 500 + 200));
@@ -63,10 +76,33 @@ export class Postman extends BaseAgent {
     this.sentThisHour++;
     this.completeTask();
 
-    return { subject, body, to: business.owner_email };
+    return { subject, body, to: business.owner_email, unsubUrl };
   }
 
-  async sendViaApi(to, subject, body, apiKey) {
+  isSuppressed(email) {
+    try {
+      const row = getDb().prepare('SELECT id FROM suppressions WHERE email = ?').get(email.toLowerCase());
+      return !!row;
+    } catch {
+      return false;
+    }
+  }
+
+  // Signed unsubscribe token so the /unsubscribe endpoint can't be spoofed
+  // to suppress arbitrary addresses.
+  buildUnsubscribeUrl(email) {
+    const base = getSetting('unsubscribe_base_url') || 'http://localhost:3001';
+    const secret = getSetting('calendly_webhook_secret') || 'scaler-dev-secret';
+    const token = crypto
+      .createHmac('sha256', secret)
+      .update(String(email || '').toLowerCase())
+      .digest('hex')
+      .slice(0, 16);
+    const q = new URLSearchParams({ e: email || '', t: token });
+    return `${base.replace(/\/+$/, '')}/api/unsubscribe?${q.toString()}`;
+  }
+
+  async sendViaApi(to, subject, body, apiKey, { unsubUrl } = {}) {
     const fromEmail = getSetting('sendgrid_from_email');
     if (!fromEmail) {
       this.logIssue(
@@ -75,6 +111,19 @@ export class Postman extends BaseAgent {
         'Set SENDGRID_FROM_EMAIL in your .env and make sure the sending domain has SPF + DKIM configured in SendGrid.',
       );
       return;
+    }
+
+    // Plaintext + minimal HTML multipart. The HTML version preserves line
+    // breaks; recipients with HTML-only clients see a readable version.
+    const htmlBody = this.toHtml(body, unsubUrl);
+
+    // List-Unsubscribe + List-Unsubscribe-Post headers enable one-click
+    // unsubscribe in Gmail / Yahoo / Apple Mail (now required for bulk
+    // senders >5K/day to hit the inbox).
+    const headers = {};
+    if (unsubUrl) {
+      headers['List-Unsubscribe'] = `<${unsubUrl}>, <mailto:unsubscribe@${fromEmail.split('@')[1] || 'example.com'}>`;
+      headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
     }
 
     try {
@@ -88,7 +137,11 @@ export class Postman extends BaseAgent {
           personalizations: [{ to: [{ email: to }] }],
           from: { email: fromEmail, name: 'Website Scaler' },
           subject,
-          content: [{ type: 'text/plain', value: body }],
+          headers,
+          content: [
+            { type: 'text/plain', value: body },
+            { type: 'text/html', value: htmlBody },
+          ],
           tracking_settings: {
             click_tracking: { enable: true, enable_text: false },
             open_tracking: { enable: true },
@@ -110,5 +163,14 @@ export class Postman extends BaseAgent {
     } catch (err) {
       this.logIssue(`Email send failed for ${to}: ${err.message}`, 'error');
     }
+  }
+
+  // Minimal HTML renderer for the plaintext body. Escapes, then converts
+  // bare URLs and newlines. Keeps the email small — no heavy framework.
+  toHtml(body, unsubUrl) {
+    const escape = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const linkify = (s) => s.replace(/(https?:\/\/[^\s<]+)/g, (u) => `<a href="${u}">${u}</a>`);
+    const html = linkify(escape(body)).replace(/\n/g, '<br>');
+    return `<!DOCTYPE html><html><body style="font-family:Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5;color:#222;max-width:640px;margin:0 auto;padding:16px;">${html}</body></html>`;
   }
 }

--- a/dashboard/server/agents/Pricer.js
+++ b/dashboard/server/agents/Pricer.js
@@ -1,13 +1,31 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getDb, getSetting, setSetting } from '../database.js';
 
-// Cost per 1K tokens by model (must match Accountant)
+// Cost per 1K tokens by model (mirrors Accountant).
 const COST_PER_1K = {
-  'claude-sonnet-4-6': 0.003,
-  'gpt-4o': 0.005,
-  'gpt-4o-mini': 0.00015,
-  default: 0.003,
+  'claude-sonnet-4-6': { input: 0.003, output: 0.015, cacheWrite: 0.00375, cacheRead: 0.0003 },
+  'claude-haiku-4-5':  { input: 0.001, output: 0.005, cacheWrite: 0.00125, cacheRead: 0.0001 },
+  'gpt-4o':            { input: 0.005, output: 0.015, cacheWrite: 0.005,   cacheRead: 0.0025 },
+  'gpt-4o-mini':       { input: 0.00015, output: 0.0006, cacheWrite: 0.00015, cacheRead: 0.000075 },
+  default:             { input: 0.003, output: 0.015, cacheWrite: 0.00375, cacheRead: 0.0003 },
 };
+
+function costTokens(usage, model) {
+  const p = COST_PER_1K[model] || COST_PER_1K.default;
+  if (typeof usage === 'number') return { tokens: usage, cost: (usage / 1000) * p.output };
+  const input = usage.input_tokens || 0;
+  const output = usage.output_tokens || 0;
+  const cacheWrite = usage.cache_creation_input_tokens || 0;
+  const cacheRead = usage.cache_read_input_tokens || 0;
+  return {
+    tokens: input + output + cacheWrite + cacheRead,
+    cost:
+      (input / 1000) * p.input +
+      (output / 1000) * p.output +
+      (cacheWrite / 1000) * p.cacheWrite +
+      (cacheRead / 1000) * p.cacheRead,
+  };
+}
 
 // Fixed costs per business (API calls, not tokens)
 const FIXED_COSTS = {
@@ -42,10 +60,9 @@ export class Pricer extends BaseAgent {
    * Track cost for a specific business.
    * Called during pipeline for each step.
    */
-  trackBusinessCost(businessId, agent, tokens, model = 'default', step = 'unknown') {
-    const db = getDb();
-    const costPer1K = COST_PER_1K[model] || COST_PER_1K.default;
-    const tokenCost = (tokens / 1000) * costPer1K;
+  // `usage` is a scalar (legacy) or a Claude `response.usage` object.
+  trackBusinessCost(businessId, agent, usage, model = 'default', step = 'unknown') {
+    const { tokens, cost: tokenCost } = costTokens(usage || 0, model);
 
     // Add fixed API costs for certain steps
     let apiCost = 0;
@@ -55,6 +72,7 @@ export class Pricer extends BaseAgent {
 
     const totalCost = tokenCost + apiCost;
 
+    const db = getDb();
     db.prepare(`
       INSERT INTO business_costs (business_id, agent_name, step, tokens_used, token_cost, api_cost, total_cost, model)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)

--- a/dashboard/server/agents/Scout.js
+++ b/dashboard/server/agents/Scout.js
@@ -1,5 +1,5 @@
 import { BaseAgent } from './BaseAgent.js';
-import { getSetting } from '../database.js';
+import { getDb, getSetting } from '../database.js';
 
 // Mock business data for when no API key is configured
 const MOCK_BUSINESSES = [
@@ -17,6 +17,38 @@ const MOCK_BUSINESSES = [
   { place_id: 'mock_12', name: 'Happy Paws Pet Grooming', category: 'pet_service', rating: 4.5, review_count: 121, address: '963 Highland Ave', phone: '(310) 555-0112', latitude: 34.0528, longitude: -118.2442 },
 ];
 
+// Hosts that are social pages or aggregator listings, not real business sites.
+// A listing whose websiteUri points here still qualifies as "no website."
+const NON_WEBSITE_HOSTS = [
+  'facebook.com', 'fb.com', 'm.facebook.com',
+  'instagram.com',
+  'twitter.com', 'x.com',
+  'tiktok.com',
+  'linkedin.com',
+  'yelp.com',
+  'tripadvisor.com',
+  'google.com', 'goo.gl', 'maps.google.com', 'sites.google.com', 'business.site',
+  'linktr.ee', 'beacons.ai', 'bio.link',
+  'youtube.com', 'youtu.be',
+  'nextdoor.com',
+  'opentable.com', 'doordash.com', 'ubereats.com', 'grubhub.com', 'seamless.com',
+  'booksy.com', 'vagaro.com', 'styleseat.com', 'fresha.com',
+  'zocdoc.com', 'healthgrades.com',
+];
+
+// Synonyms so users typing "cafe" still match mock restaurants, etc.
+const CATEGORY_SYNONYMS = {
+  restaurant: ['restaurant', 'cafe', 'bar', 'food', 'meal_takeaway'],
+  bakery: ['bakery'],
+  salon: ['salon', 'beauty_salon', 'hair_care', 'nail_salon', 'spa', 'barber'],
+  gym: ['gym', 'yoga', 'fitness'],
+  dentist: ['dentist', 'doctor', 'medical'],
+  lawyer: ['lawyer', 'attorney', 'legal'],
+  florist: ['florist', 'flower'],
+  auto_repair: ['auto_repair', 'car_repair', 'mechanic'],
+  pet_service: ['pet_service', 'pet_store', 'pet_grooming', 'veterinary'],
+};
+
 export class Scout extends BaseAgent {
   constructor(broadcast) {
     super('Scout', broadcast);
@@ -25,9 +57,10 @@ export class Scout extends BaseAgent {
   async findBusinesses(zipCode, category, limit = 10) {
     this.heartbeat();
     const apiKey = getSetting('google_maps_api_key');
+    const seen = this.loadSeenPlaceIds();
 
     if (apiKey) {
-      return this.findBusinessesFromApi(zipCode, category, limit, apiKey);
+      return this.findBusinessesFromApi(zipCode, category, limit, apiKey, seen);
     }
 
     // Mock mode
@@ -35,7 +68,8 @@ export class Scout extends BaseAgent {
     await this.simulateDelay(800, 2000);
 
     const filtered = MOCK_BUSINESSES
-      .filter((b) => !category || b.category === category || category === 'all')
+      .filter((b) => this.categoryMatches(category, b.category))
+      .filter((b) => !seen.has(`${b.place_id}_${zipCode}`))
       .slice(0, limit)
       .map((b) => ({
         ...b,
@@ -48,10 +82,10 @@ export class Scout extends BaseAgent {
     return filtered;
   }
 
-  async findBusinessesFromApi(zipCode, category, limit, apiKey) {
+  async findBusinessesFromApi(zipCode, category, limit, apiKey, seen) {
     // Places API (New) v1 Text Search. Field mask keeps cost minimal — we only
     // pay for fields we request. `websiteUri` is how we filter: if the listing
-    // has a website, we skip it (that's our qualifier — they don't need us).
+    // has a real website, we skip it (that's our qualifier — they don't need us).
     const query = `${category === 'all' ? 'businesses' : category} in ${zipCode}`;
     const fieldMask = [
       'places.id',
@@ -70,6 +104,9 @@ export class Scout extends BaseAgent {
     const qualified = [];
     let pageToken;
     let requestsMade = 0;
+    let skippedHasWebsite = 0;
+    let skippedCategory = 0;
+    let skippedDupe = 0;
 
     try {
       do {
@@ -100,11 +137,16 @@ export class Scout extends BaseAgent {
         requestsMade++;
 
         for (const p of data.places || []) {
-          if (p.websiteUri) continue; // already has a site — skip
+          if (this.hasRealWebsite(p.websiteUri)) { skippedHasWebsite++; continue; }
+          if (seen.has(p.id)) { skippedDupe++; continue; }
+
+          const inferred = this.inferCategory(p.types);
+          if (!this.categoryMatches(category, inferred)) { skippedCategory++; continue; }
+
           qualified.push({
             place_id: p.id,
             name: p.displayName?.text || '',
-            category: category || this.inferCategory(p.types),
+            category: category && category !== 'all' ? category : inferred,
             rating: p.rating,
             review_count: p.userRatingCount,
             address: p.formattedAddress || '',
@@ -113,6 +155,7 @@ export class Scout extends BaseAgent {
             longitude: p.location?.longitude,
             maps_url: p.googleMapsUri,
           });
+          seen.add(p.id);
           if (qualified.length >= limit) break;
         }
 
@@ -120,7 +163,9 @@ export class Scout extends BaseAgent {
       } while (pageToken && qualified.length < limit && requestsMade < 3);
 
       this.log(
-        `Found ${qualified.length} businesses without websites in ${zipCode} (${requestsMade} API calls)`,
+        `Found ${qualified.length} businesses without websites in ${zipCode} ` +
+          `(${requestsMade} API calls; skipped ${skippedHasWebsite} with site, ` +
+          `${skippedCategory} off-category, ${skippedDupe} dupes)`,
         qualified.length > 0 ? 'success' : 'warning',
       );
       this.completeTask();
@@ -128,6 +173,35 @@ export class Scout extends BaseAgent {
     } catch (err) {
       this.logIssue(`Scout API call failed: ${err.message}`, 'error');
       return [];
+    }
+  }
+
+  // Treat empty, social, and aggregator URLs as "no real website."
+  hasRealWebsite(url) {
+    if (!url) return false;
+    let host;
+    try {
+      host = new URL(url).hostname.toLowerCase().replace(/^www\./, '');
+    } catch {
+      return false;
+    }
+    return !NON_WEBSITE_HOSTS.some((bad) => host === bad || host.endsWith(`.${bad}`));
+  }
+
+  categoryMatches(requested, actual) {
+    if (!requested || requested === 'all') return true;
+    const synonyms = CATEGORY_SYNONYMS[requested];
+    if (synonyms) return synonyms.includes(actual);
+    return actual === requested;
+  }
+
+  // Place IDs already in our DB — skip them so Scraper doesn't re-fetch.
+  loadSeenPlaceIds() {
+    try {
+      const rows = getDb().prepare('SELECT place_id FROM businesses WHERE place_id IS NOT NULL').all();
+      return new Set(rows.map((r) => r.place_id));
+    } catch {
+      return new Set();
     }
   }
 

--- a/dashboard/server/agents/Scout.js
+++ b/dashboard/server/agents/Scout.js
@@ -98,8 +98,12 @@ export class Scout extends BaseAgent {
       'places.nationalPhoneNumber',
       'places.location',
       'places.googleMapsUri',
+      'places.businessStatus',
       'nextPageToken',
     ].join(',');
+
+    const minReviews = parseInt(getSetting('min_review_count')) || 0;
+    const seenPhones = this.loadSeenPhones();
 
     const qualified = [];
     let pageToken;
@@ -107,6 +111,9 @@ export class Scout extends BaseAgent {
     let skippedHasWebsite = 0;
     let skippedCategory = 0;
     let skippedDupe = 0;
+    let skippedLowReviews = 0;
+    let skippedClosed = 0;
+    let skippedPhoneDupe = 0;
 
     try {
       do {
@@ -137,11 +144,19 @@ export class Scout extends BaseAgent {
         requestsMade++;
 
         for (const p of data.places || []) {
+          if (p.businessStatus && p.businessStatus !== 'OPERATIONAL') { skippedClosed++; continue; }
           if (this.hasRealWebsite(p.websiteUri)) { skippedHasWebsite++; continue; }
           if (seen.has(p.id)) { skippedDupe++; continue; }
 
           const inferred = this.inferCategory(p.types);
           if (!this.categoryMatches(category, inferred)) { skippedCategory++; continue; }
+
+          if (minReviews > 0 && (p.userRatingCount || 0) < minReviews) {
+            skippedLowReviews++; continue;
+          }
+
+          const phoneKey = this.normalizePhone(p.nationalPhoneNumber);
+          if (phoneKey && seenPhones.has(phoneKey)) { skippedPhoneDupe++; continue; }
 
           qualified.push({
             place_id: p.id,
@@ -156,6 +171,7 @@ export class Scout extends BaseAgent {
             maps_url: p.googleMapsUri,
           });
           seen.add(p.id);
+          if (phoneKey) seenPhones.add(phoneKey);
           if (qualified.length >= limit) break;
         }
 
@@ -165,7 +181,8 @@ export class Scout extends BaseAgent {
       this.log(
         `Found ${qualified.length} businesses without websites in ${zipCode} ` +
           `(${requestsMade} API calls; skipped ${skippedHasWebsite} with site, ` +
-          `${skippedCategory} off-category, ${skippedDupe} dupes)`,
+          `${skippedCategory} off-category, ${skippedDupe} dupes, ` +
+          `${skippedClosed} closed, ${skippedLowReviews} low-reviews, ${skippedPhoneDupe} phone-dupes)`,
         qualified.length > 0 ? 'success' : 'warning',
       );
       this.completeTask();
@@ -203,6 +220,24 @@ export class Scout extends BaseAgent {
     } catch {
       return new Set();
     }
+  }
+
+  // Phones already in our DB (normalized) — catches the same business
+  // registered twice under different place_ids.
+  loadSeenPhones() {
+    try {
+      const rows = getDb().prepare('SELECT phone FROM businesses WHERE phone IS NOT NULL').all();
+      return new Set(rows.map((r) => this.normalizePhone(r.phone)).filter(Boolean));
+    } catch {
+      return new Set();
+    }
+  }
+
+  normalizePhone(phone) {
+    if (!phone) return '';
+    const digits = String(phone).replace(/\D/g, '');
+    // Strip a leading country code if present (US-centric today).
+    return digits.length > 10 ? digits.slice(-10) : digits;
   }
 
   inferCategory(types = []) {

--- a/dashboard/server/agents/Scout.js
+++ b/dashboard/server/agents/Scout.js
@@ -104,6 +104,8 @@ export class Scout extends BaseAgent {
 
     const minReviews = parseInt(getSetting('min_review_count')) || 0;
     const seenPhones = this.loadSeenPhones();
+    const seenAddrs = this.loadSeenAddresses();
+    const negativeKeywords = this.loadNegativeKeywords();
 
     const qualified = [];
     let pageToken;
@@ -114,6 +116,8 @@ export class Scout extends BaseAgent {
     let skippedLowReviews = 0;
     let skippedClosed = 0;
     let skippedPhoneDupe = 0;
+    let skippedAddressDupe = 0;
+    let skippedNegative = 0;
 
     try {
       do {
@@ -158,6 +162,12 @@ export class Scout extends BaseAgent {
           const phoneKey = this.normalizePhone(p.nationalPhoneNumber);
           if (phoneKey && seenPhones.has(phoneKey)) { skippedPhoneDupe++; continue; }
 
+          const addrKey = this.normalizeAddress(p.formattedAddress);
+          if (addrKey && seenAddrs.has(addrKey)) { skippedAddressDupe++; continue; }
+
+          const nameLower = (p.displayName?.text || '').toLowerCase();
+          if (negativeKeywords.some((kw) => nameLower.includes(kw))) { skippedNegative++; continue; }
+
           qualified.push({
             place_id: p.id,
             name: p.displayName?.text || '',
@@ -172,6 +182,7 @@ export class Scout extends BaseAgent {
           });
           seen.add(p.id);
           if (phoneKey) seenPhones.add(phoneKey);
+          if (addrKey) seenAddrs.add(addrKey);
           if (qualified.length >= limit) break;
         }
 
@@ -182,7 +193,9 @@ export class Scout extends BaseAgent {
         `Found ${qualified.length} businesses without websites in ${zipCode} ` +
           `(${requestsMade} API calls; skipped ${skippedHasWebsite} with site, ` +
           `${skippedCategory} off-category, ${skippedDupe} dupes, ` +
-          `${skippedClosed} closed, ${skippedLowReviews} low-reviews, ${skippedPhoneDupe} phone-dupes)`,
+          `${skippedClosed} closed, ${skippedLowReviews} low-reviews, ` +
+          `${skippedPhoneDupe} phone-dupes, ${skippedAddressDupe} addr-dupes, ` +
+          `${skippedNegative} negative-keyword)`,
         qualified.length > 0 ? 'success' : 'warning',
       );
       this.completeTask();
@@ -238,6 +251,43 @@ export class Scout extends BaseAgent {
     const digits = String(phone).replace(/\D/g, '');
     // Strip a leading country code if present (US-centric today).
     return digits.length > 10 ? digits.slice(-10) : digits;
+  }
+
+  // Coarse address normalization: lowercase, drop punctuation, collapse
+  // whitespace, and keep only the first line (drop the city/state tail
+  // that Places appends). Catches "123 Main St, Beverly Hills, CA" vs
+  // "123 Main Street" collisions.
+  normalizeAddress(addr) {
+    if (!addr) return '';
+    const firstLine = String(addr).split(',')[0] || '';
+    return firstLine
+      .toLowerCase()
+      .replace(/\bstreet\b/g, 'st')
+      .replace(/\bavenue\b/g, 'ave')
+      .replace(/\bboulevard\b/g, 'blvd')
+      .replace(/\broad\b/g, 'rd')
+      .replace(/\bdrive\b/g, 'dr')
+      .replace(/[^\w\s]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  loadSeenAddresses() {
+    try {
+      const rows = getDb().prepare('SELECT address FROM businesses WHERE address IS NOT NULL').all();
+      return new Set(rows.map((r) => this.normalizeAddress(r.address)).filter(Boolean));
+    } catch {
+      return new Set();
+    }
+  }
+
+  // Comma-separated list from settings. "vape,smoke,cannabis" etc.
+  loadNegativeKeywords() {
+    const raw = getSetting('scout_negative_keywords') || '';
+    return raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
   }
 
   inferCategory(types = []) {

--- a/dashboard/server/agents/Scraper.js
+++ b/dashboard/server/agents/Scraper.js
@@ -1,5 +1,5 @@
 import { BaseAgent } from './BaseAgent.js';
-import { getSetting } from '../database.js';
+import { getDb, getSetting } from '../database.js';
 
 const MOCK_OWNERS = [
   { name: 'Rosa Martinez', email: 'rosa@mamabakery.com' },
@@ -131,23 +131,24 @@ export class Scraper extends BaseAgent {
         if (day && rest.length) hours[day.trim().toLowerCase()] = rest.join(':').trim();
       }
 
-      // Photos: resolve the first 3 to usable URLs. `skipHttpRedirect` returns
+      // Photos: resolve up to 3 in parallel. `skipHttpRedirect` returns
       // JSON with the final photo URL instead of a redirect.
-      const photos = [];
-      for (const ph of (p.photos || []).slice(0, 3)) {
-        try {
-          const pr = await fetch(
-            `https://places.googleapis.com/v1/${ph.name}/media?maxWidthPx=1200&skipHttpRedirect=true`,
-            { headers: { 'X-Goog-Api-Key': apiKey } },
-          );
-          if (pr.ok) {
+      const photoResults = await Promise.all(
+        (p.photos || []).slice(0, 3).map(async (ph) => {
+          try {
+            const pr = await fetch(
+              `https://places.googleapis.com/v1/${ph.name}/media?maxWidthPx=1200&skipHttpRedirect=true`,
+              { headers: { 'X-Goog-Api-Key': apiKey } },
+            );
+            if (!pr.ok) return null;
             const { photoUri } = await pr.json();
-            if (photoUri) photos.push(photoUri);
+            return photoUri || null;
+          } catch {
+            return null;
           }
-        } catch (_) {
-          // non-fatal — just skip this photo
-        }
-      }
+        }),
+      );
+      const photos = photoResults.filter(Boolean);
 
       const category = business.category || 'restaurant';
       const services = MOCK_SERVICES[category] || MOCK_SERVICES.restaurant;
@@ -188,7 +189,26 @@ export class Scraper extends BaseAgent {
       return enriched;
     } catch (err) {
       this.logIssue(`Scraper API call failed for ${business.name}: ${err.message}`, 'warning');
+      this.recordFailure(business, err.message);
       return null;
+    }
+  }
+
+  // Persist enrichment failures so we can see which upstream errors recur
+  // without flooding the issues table with one row per attempt.
+  recordFailure(business, reason) {
+    if (!business?.place_id) return;
+    try {
+      getDb().prepare(`
+        INSERT INTO enrichment_failures (place_id, business_name, reason)
+        VALUES (?, ?, ?)
+        ON CONFLICT(place_id) DO UPDATE SET
+          attempts = attempts + 1,
+          last_attempt_at = CURRENT_TIMESTAMP,
+          reason = excluded.reason
+      `).run(business.place_id, business.name || null, String(reason).slice(0, 500));
+    } catch (_) {
+      // non-fatal
     }
   }
 }

--- a/dashboard/server/agents/Sentinel.js
+++ b/dashboard/server/agents/Sentinel.js
@@ -1,5 +1,11 @@
 import { BaseAgent } from './BaseAgent.js';
 import { getDb, getSetting } from '../database.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = path.join(__dirname, '..', '..', 'data', 'scaler.db');
 
 export class SentinelClient extends BaseAgent {
   constructor(broadcast) {
@@ -26,12 +32,16 @@ export class SentinelClient extends BaseAgent {
     // Check API keys every 60 seconds
     this.apiCheckInterval = setInterval(() => this.checkApiKeys(), 60000);
 
+    // Resource checks every 60 seconds (disk, DB size, error rate).
+    this.resourceInterval = setInterval(() => this.checkResources(), 60000);
+
     this.log('Sentinel online — monitoring all agents', 'success');
   }
 
   async stop() {
     if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
     if (this.apiCheckInterval) clearInterval(this.apiCheckInterval);
+    if (this.resourceInterval) clearInterval(this.resourceInterval);
 
     const db = getDb();
     db.prepare("INSERT INTO uptime_logs (event_type, agent_name, details) VALUES (?, ?, ?)").run('stop', 'Sentinel', 'Sentinel service stopped');
@@ -193,6 +203,89 @@ export class SentinelClient extends BaseAgent {
 
     this.broadcast('preflight_results', { results, allPass });
     return { results, allPass };
+  }
+
+  // Resource checks — disk, DB size, error rate, memory. Each fires a
+  // single issue when it crosses the threshold; the issues are idempotent
+  // (we check recent unresolved rows before re-logging).
+  checkResources() {
+    try {
+      // DB file size — SQLite bloat is a classic operational pitfall.
+      if (fs.existsSync(DB_PATH)) {
+        const bytes = fs.statSync(DB_PATH).size;
+        const mb = bytes / (1024 * 1024);
+        this.broadcast('resource_check', { kind: 'db_size_mb', value: Math.round(mb) });
+        if (mb > 500) {
+          this.logIssueOnce(
+            'db_size_large',
+            `SQLite DB is ${Math.round(mb)} MB`,
+            'warning',
+            'Archive old agent_logs rows and run VACUUM, or plan a migration to Postgres.'
+          );
+        }
+      }
+
+      // WAL file — unbounded growth is a known SQLite footgun.
+      const walPath = DB_PATH + '-wal';
+      if (fs.existsSync(walPath)) {
+        const walMb = fs.statSync(walPath).size / (1024 * 1024);
+        this.broadcast('resource_check', { kind: 'wal_size_mb', value: Math.round(walMb) });
+        if (walMb > 100) {
+          this.logIssueOnce(
+            'wal_size_large',
+            `WAL file is ${Math.round(walMb)} MB`,
+            'warning',
+            'Run PRAGMA wal_checkpoint(TRUNCATE) or restart the server to flush the WAL.'
+          );
+        }
+      }
+
+      // Error rate — flag if > 5 errors in the last 5 minutes.
+      const db = getDb();
+      const recentErrors = db.prepare(
+        "SELECT COUNT(*) as n FROM agent_logs WHERE status = 'error' AND datetime(created_at) > datetime('now', '-5 minutes')"
+      ).get().n;
+      this.broadcast('resource_check', { kind: 'errors_5m', value: recentErrors });
+      if (recentErrors > 5) {
+        this.logIssueOnce(
+          'error_rate_high',
+          `${recentErrors} errors in the last 5 minutes`,
+          'error',
+          'Check recent agent_logs for the common failure mode. Consider pausing the pipeline.'
+        );
+      }
+
+      // Heap memory — alert >512MB which usually means a leak in a long run.
+      const heapMb = process.memoryUsage().heapUsed / (1024 * 1024);
+      this.broadcast('resource_check', { kind: 'heap_mb', value: Math.round(heapMb) });
+      if (heapMb > 512) {
+        this.logIssueOnce(
+          'heap_high',
+          `Node heap at ${Math.round(heapMb)} MB`,
+          'warning',
+          'Consider restarting the process; investigate for leaks in long-running agent state.'
+        );
+      }
+    } catch (err) {
+      // Never let monitoring crash the monitor.
+      console.warn('[Sentinel] resource check error:', err.message);
+    }
+  }
+
+  // Dedupes issues: only logs a given `key` if there isn't already an
+  // unresolved issue with the same suggested_fix tag.
+  logIssueOnce(key, description, severity, suggestedFix) {
+    try {
+      const db = getDb();
+      const existing = db.prepare(
+        "SELECT id FROM issues WHERE resolved = 0 AND suggested_fix LIKE ?"
+      ).get(`%[${key}]%`);
+      if (existing) return;
+      const tagged = `[${key}] ${suggestedFix}`;
+      this.logIssue(description, severity, tagged);
+    } catch {
+      this.logIssue(description, severity, suggestedFix);
+    }
   }
 
   getSecurityReport() {

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -193,6 +193,38 @@ function initSchema() {
       FOREIGN KEY (site_id) REFERENCES sites(id)
     );
 
+    CREATE TABLE IF NOT EXISTS suppressions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL,
+      reason TEXT,
+      source TEXT,
+      tenant_id INTEGER DEFAULT 1,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(email, tenant_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS enrichment_failures (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      place_id TEXT NOT NULL,
+      business_name TEXT,
+      reason TEXT,
+      attempts INTEGER DEFAULT 1,
+      last_attempt_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(place_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS audit_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor TEXT,
+      action TEXT NOT NULL,
+      target_type TEXT,
+      target_id TEXT,
+      request_id TEXT,
+      metadata TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
     CREATE INDEX IF NOT EXISTS idx_businesses_zip_status ON businesses(zip_code, status);
     CREATE INDEX IF NOT EXISTS idx_businesses_status ON businesses(status);
     CREATE INDEX IF NOT EXISTS idx_sites_business ON sites(business_id);
@@ -205,6 +237,10 @@ function initSchema() {
     CREATE INDEX IF NOT EXISTS idx_scheduled_calls_time ON scheduled_calls(scheduled_at);
     CREATE INDEX IF NOT EXISTS idx_scheduled_calls_status ON scheduled_calls(status);
     CREATE INDEX IF NOT EXISTS idx_scheduled_calls_business ON scheduled_calls(business_id);
+    CREATE INDEX IF NOT EXISTS idx_suppressions_email ON suppressions(email);
+    CREATE INDEX IF NOT EXISTS idx_enrichment_failures_place ON enrichment_failures(place_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_created ON audit_log(created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target_type, target_id);
   `);
 
   // Phase-2 groundwork: add a nullable tenant_id to the big tables so we can
@@ -238,6 +274,9 @@ function initSchema() {
     price_sample_size: '0',
     calendly_link: '',
     calendly_webhook_secret: '',
+    sender_physical_address: '',
+    unsubscribe_base_url: '',
+    min_review_count: '5',
   };
   for (const [key, value] of Object.entries(defaults)) {
     insertSetting.run(key, value);

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -12,9 +12,44 @@ export function getDb() {
     db = new Database(DB_PATH);
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');
+    // Block-waiting up to 5s on SQLITE_BUSY beats surfacing transient
+    // contention to callers. WAL mode mostly avoids writer starvation,
+    // but the periodic checkpoint + vacuum jobs can still collide.
+    db.pragma('busy_timeout = 5000');
+    db.pragma('synchronous = NORMAL');
     initSchema();
   }
   return db;
+}
+
+// Periodic WAL checkpoint — caps the -wal file which otherwise grows
+// unbounded on long-running processes. TRUNCATE is the strongest mode:
+// it flushes the WAL and then resets the file to zero bytes.
+export function startWalCheckpoint(intervalMs = 10 * 60_000) {
+  return setInterval(() => {
+    try {
+      getDb().pragma('wal_checkpoint(TRUNCATE)');
+    } catch (err) {
+      console.warn('[DB] wal_checkpoint failed:', err.message);
+    }
+  }, intervalMs).unref();
+}
+
+// Archive agent_logs older than `days` into a sibling table and delete
+// the originals. Keeps the primary table small for snappy dashboard reads.
+export function archiveOldLogs(days = 30) {
+  const d = getDb();
+  try {
+    d.exec(`CREATE TABLE IF NOT EXISTS agent_logs_archive AS SELECT * FROM agent_logs WHERE 0`);
+    const cutoff = `datetime('now', '-${Number(days) | 0} days')`;
+    d.exec(`
+      INSERT INTO agent_logs_archive
+        SELECT * FROM agent_logs WHERE created_at < ${cutoff};
+      DELETE FROM agent_logs WHERE created_at < ${cutoff};
+    `);
+  } catch (err) {
+    console.warn('[DB] archive failed:', err.message);
+  }
 }
 
 function initSchema() {
@@ -253,6 +288,55 @@ function initSchema() {
     }
   }
 
+  // Soft-delete groundwork on businesses so we can "undelete" for 30d
+  // without destroying data outright.
+  {
+    const cols = db.prepare('PRAGMA table_info(businesses)').all();
+    if (!cols.some((c) => c.name === 'deleted_at')) {
+      db.exec('ALTER TABLE businesses ADD COLUMN deleted_at DATETIME');
+    }
+    if (!cols.some((c) => c.name === 'notes')) {
+      db.exec('ALTER TABLE businesses ADD COLUMN notes TEXT');
+    }
+  }
+  // Notes + outcome tracking on scheduled_calls.
+  {
+    const cols = db.prepare('PRAGMA table_info(scheduled_calls)').all();
+    if (!cols.some((c) => c.name === 'notes')) {
+      db.exec('ALTER TABLE scheduled_calls ADD COLUMN notes TEXT');
+    }
+    if (!cols.some((c) => c.name === 'outcome')) {
+      db.exec('ALTER TABLE scheduled_calls ADD COLUMN outcome TEXT');
+    }
+  }
+
+  // FTS5 virtual table mirroring `businesses` so the Leads search is O(log n)
+  // on large lead lists instead of an N× LIKE scan.
+  try {
+    db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS businesses_fts USING fts5(
+        name, address, phone, category, content='businesses', content_rowid='id'
+      );
+      CREATE TRIGGER IF NOT EXISTS businesses_ai AFTER INSERT ON businesses BEGIN
+        INSERT INTO businesses_fts(rowid, name, address, phone, category)
+        VALUES (new.id, new.name, new.address, new.phone, new.category);
+      END;
+      CREATE TRIGGER IF NOT EXISTS businesses_ad AFTER DELETE ON businesses BEGIN
+        INSERT INTO businesses_fts(businesses_fts, rowid, name, address, phone, category)
+        VALUES('delete', old.id, old.name, old.address, old.phone, old.category);
+      END;
+      CREATE TRIGGER IF NOT EXISTS businesses_au AFTER UPDATE ON businesses BEGIN
+        INSERT INTO businesses_fts(businesses_fts, rowid, name, address, phone, category)
+        VALUES('delete', old.id, old.name, old.address, old.phone, old.category);
+        INSERT INTO businesses_fts(rowid, name, address, phone, category)
+        VALUES (new.id, new.name, new.address, new.phone, new.category);
+      END;
+    `);
+  } catch (err) {
+    // FTS5 may be unavailable in very old SQLite builds — fall back silently.
+    console.warn('[DB] FTS5 init skipped:', err.message);
+  }
+
   // Insert default settings if not present
   const insertSetting = db.prepare(
     'INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)'
@@ -274,9 +358,12 @@ function initSchema() {
     price_sample_size: '0',
     calendly_link: '',
     calendly_webhook_secret: '',
+    sendgrid_webhook_public_key: '',
     sender_physical_address: '',
     unsubscribe_base_url: '',
     min_review_count: '5',
+    scout_negative_keywords: '',
+    suppress_generic_addresses: '1',
   };
   for (const [key, value] of Object.entries(defaults)) {
     insertSetting.run(key, value);

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -311,8 +311,13 @@ function initSchema() {
   }
 
   // FTS5 virtual table mirroring `businesses` so the Leads search is O(log n)
-  // on large lead lists instead of an N× LIKE scan.
+  // on large lead lists instead of an N× LIKE scan. Triggers keep it in
+  // sync on insert/update/delete; we also backfill existing rows the first
+  // time the FTS table is created so upgrades don't start with empty search.
   try {
+    const existed = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='businesses_fts'")
+      .get();
     db.exec(`
       CREATE VIRTUAL TABLE IF NOT EXISTS businesses_fts USING fts5(
         name, address, phone, category, content='businesses', content_rowid='id'
@@ -332,6 +337,9 @@ function initSchema() {
         VALUES (new.id, new.name, new.address, new.phone, new.category);
       END;
     `);
+    if (!existed) {
+      db.exec("INSERT INTO businesses_fts(businesses_fts) VALUES('rebuild')");
+    }
   } catch (err) {
     // FTS5 may be unavailable in very old SQLite builds — fall back silently.
     console.warn('[DB] FTS5 init skipped:', err.message);

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -177,6 +177,22 @@ function initSchema() {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
 
+    CREATE TABLE IF NOT EXISTS scheduled_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      business_id INTEGER NOT NULL,
+      site_id INTEGER,
+      scheduled_at DATETIME NOT NULL,
+      booker_name TEXT,
+      booker_email TEXT,
+      provider TEXT DEFAULT 'calendly',
+      provider_event_id TEXT UNIQUE,
+      status TEXT DEFAULT 'scheduled',
+      tenant_id INTEGER DEFAULT 1,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (business_id) REFERENCES businesses(id),
+      FOREIGN KEY (site_id) REFERENCES sites(id)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_businesses_zip_status ON businesses(zip_code, status);
     CREATE INDEX IF NOT EXISTS idx_businesses_status ON businesses(status);
     CREATE INDEX IF NOT EXISTS idx_sites_business ON sites(business_id);
@@ -186,7 +202,20 @@ function initSchema() {
     CREATE INDEX IF NOT EXISTS idx_token_usage_created ON token_usage(created_at);
     CREATE INDEX IF NOT EXISTS idx_agent_logs_created ON agent_logs(created_at);
     CREATE INDEX IF NOT EXISTS idx_issues_resolved ON issues(resolved, created_at);
+    CREATE INDEX IF NOT EXISTS idx_scheduled_calls_time ON scheduled_calls(scheduled_at);
+    CREATE INDEX IF NOT EXISTS idx_scheduled_calls_status ON scheduled_calls(status);
+    CREATE INDEX IF NOT EXISTS idx_scheduled_calls_business ON scheduled_calls(business_id);
   `);
+
+  // Phase-2 groundwork: add a nullable tenant_id to the big tables so we can
+  // multi-tenant later without a painful migration. Default 1 for today's
+  // single-tenant use. Uses ALTER TABLE ADD COLUMN + IF NOT EXISTS guard.
+  for (const tbl of ['businesses', 'sites', 'emails', 'sales', 'scheduled_calls']) {
+    const cols = db.prepare(`PRAGMA table_info(${tbl})`).all();
+    if (!cols.some((c) => c.name === 'tenant_id')) {
+      db.exec(`ALTER TABLE ${tbl} ADD COLUMN tenant_id INTEGER DEFAULT 1`);
+    }
+  }
 
   // Insert default settings if not present
   const insertSetting = db.prepare(
@@ -207,6 +236,8 @@ function initSchema() {
     current_price: '50',
     avg_cost_per_business: '0',
     price_sample_size: '0',
+    calendly_link: '',
+    calendly_webhook_secret: '',
   };
   for (const [key, value] of Object.entries(defaults)) {
     insertSetting.run(key, value);

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -176,6 +176,16 @@ function initSchema() {
       finished_at DATETIME,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
+
+    CREATE INDEX IF NOT EXISTS idx_businesses_zip_status ON businesses(zip_code, status);
+    CREATE INDEX IF NOT EXISTS idx_businesses_status ON businesses(status);
+    CREATE INDEX IF NOT EXISTS idx_sites_business ON sites(business_id);
+    CREATE INDEX IF NOT EXISTS idx_emails_status_sent ON emails(status, sent_at);
+    CREATE INDEX IF NOT EXISTS idx_emails_business ON emails(business_id);
+    CREATE INDEX IF NOT EXISTS idx_business_costs_business ON business_costs(business_id);
+    CREATE INDEX IF NOT EXISTS idx_token_usage_created ON token_usage(created_at);
+    CREATE INDEX IF NOT EXISTS idx_agent_logs_created ON agent_logs(created_at);
+    CREATE INDEX IF NOT EXISTS idx_issues_resolved ON issues(resolved, created_at);
   `);
 
   // Insert default settings if not present

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -63,8 +63,18 @@ app.use('/api/deploy', rateLimit({ max: 3, windowMs: 60_000, name: 'deploy' }));
 app.use('/api/stop', rateLimit({ max: 10, windowMs: 60_000, name: 'stop' }));
 app.use('/api/calendly/webhook', rateLimit({ max: 60, windowMs: 60_000, name: 'calendly' }));
 
-// Serve generated sites
+// Serve generated sites. Anything under /sites/* that isn't a real file
+// returns a clear 404 instead of falling through to the dashboard SPA
+// (which was showing the dashboard shell for broken preview URLs).
 app.use('/sites', express.static(path.join(__dirname, '..', 'generated-sites')));
+app.use('/sites', (req, res) => {
+  res.status(404).type('html').send(
+    '<!doctype html><body style="font-family:sans-serif;max-width:420px;margin:40px auto;text-align:center">' +
+    '<h2>This demo site has moved or expired</h2>' +
+    '<p>If you believe this is an error, reply to the email we sent and we\'ll rebuild it.</p>' +
+    '</body>'
+  );
+});
 
 // Serve frontend in production
 app.use(express.static(path.join(__dirname, '..', 'client', 'dist')));

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -3,7 +3,7 @@ import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createServer } from 'http';
-import { getDb } from './database.js';
+import { getDb, startWalCheckpoint, archiveOldLogs } from './database.js';
 import { initWebSocket, broadcast } from './services/websocket.js';
 import apiRoutes from './routes/api.js';
 import settingsRoutes from './routes/settings.js';
@@ -37,7 +37,14 @@ app.set('trust proxy', 1);
 app.use(requestId());
 app.use(securityHeaders());
 app.use(cors({ origin: corsOriginList(), credentials: true }));
-app.use(express.json({ limit: '1mb' }));
+// Preserve the raw request body on every JSON request so webhook handlers
+// can verify signatures. The verify callback is synchronous and runs before
+// parsing, so req.rawBody is populated by the time the route handler sees
+// the parsed `req.body`.
+app.use(express.json({
+  limit: '1mb',
+  verify: (req, res, buf) => { req.rawBody = buf ? buf.toString('utf8') : ''; },
+}));
 app.use(accessLog());
 
 // Health endpoints — cheap checks used by uptime monitors + load balancers.
@@ -64,6 +71,14 @@ app.use(express.static(path.join(__dirname, '..', 'client', 'dist')));
 
 // Init database
 getDb();
+
+// Cron-lite: periodic WAL checkpoint and nightly log archive.
+startWalCheckpoint(10 * 60_000);
+// First archive at +6h from boot, then every 24h.
+setTimeout(() => {
+  archiveOldLogs(30);
+  setInterval(() => archiveOldLogs(30), 24 * 3600_000).unref();
+}, 6 * 3600_000).unref();
 
 // Init WebSocket
 initWebSocket(server);
@@ -105,7 +120,7 @@ app.post('/api/deploy', async (req, res) => {
     return res.status(400).json({ error: 'Pipeline already running' });
   }
 
-  const { zipCodes = ['90210'], categories = ['restaurant'], maxLeads = 20, dailyEmailLimit = 50 } = req.body;
+  const { zipCodes = ['90210'], categories = ['restaurant'], maxLeads = 20, dailyEmailLimit = 50, dryRun = false } = req.body;
 
   const db = getDb();
 
@@ -138,7 +153,7 @@ app.post('/api/deploy', async (req, res) => {
   broadcast('deploy', { status: 'all_agents_online' });
 
   // Start the pipeline
-  runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit).catch((err) => {
+  runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit, { dryRun }).catch((err) => {
     console.error('[Pipeline] Error:', err.message);
     broadcast('pipeline_error', { error: err.message });
   });
@@ -188,7 +203,10 @@ app.get('/api/pipeline/status', (req, res) => {
   });
 });
 
-async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
+async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit, { dryRun = false } = {}) {
+  if (dryRun) {
+    agents.commander.log('DRY RUN — no emails will be sent, no DB writes for leads', 'info');
+  }
   const db = getDb();
   const builderAgents = [agents.builderAlpha, agents.builderBeta, agents.builderGamma];
   const concurrency = builderAgents.length;
@@ -201,6 +219,16 @@ async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
   async function processLead(biz) {
     // Scraper enriches data
     const enriched = await agents.scraper.enrichBusiness(biz);
+
+    if (dryRun) {
+      broadcast('dry_run_lead', {
+        name: enriched.name, category: enriched.category,
+        rating: enriched.rating, reviews: enriched.review_count,
+        owner_email: enriched.owner_email, phone: enriched.phone,
+      });
+      totalProcessed++;
+      return;
+    }
 
     // Save to database
     const existing = db.prepare('SELECT id FROM businesses WHERE place_id = ?').get(enriched.place_id);

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -180,7 +180,7 @@ async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
         JSON.stringify(enriched.hours), JSON.stringify(enriched.photos),
         JSON.stringify(enriched.services), enriched.owner_name, enriched.owner_email,
         biz.zip_code || enriched.address?.match(/\b\d{5}\b/)?.[0] || null,
-        JSON.stringify(enriched), 'scraped',
+        JSON.stringify(enriched), 'pitched',
         enriched.rating ? Math.round(enriched.rating * (enriched.review_count || 0)) : 0
       );
       businessId = result.lastInsertRowid;
@@ -190,41 +190,19 @@ async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
     agents.pricer.trackBusinessCost(businessId, 'Scout', 0, 'default', 'find');
     agents.pricer.trackBusinessCost(businessId, 'Scraper', 0, 'default', 'scrape');
 
-    // Round-robin across builder pool
-    const builder = builderAgents[builderIndex++ % builderAgents.length];
-    agents.commander.log(`Assigning ${enriched.name} to ${builder.name}`);
+    // Builder no longer runs here — the pitch is for a call. Builder runs
+    // after the prospect books via Calendly (see /api/calendly/webhook).
 
-    const siteResult = await builder.buildSite(enriched);
-
-    const siteRow = db.prepare(
-      'INSERT INTO sites (business_id, builder_agent, html_path, preview_url, build_time_ms, design_style, status) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).run(businessId, builder.name, siteResult.htmlPath, siteResult.previewUrl, siteResult.buildTime, siteResult.designStyle, 'completed');
-
-    // Real token usage from Claude's response.usage when available.
-    if (siteResult.usage) {
-      agents.accountant.trackUsage(builder.name, siteResult.usage, siteResult.model);
-      agents.pricer.trackBusinessCost(businessId, builder.name, siteResult.usage, siteResult.model, 'build');
-    }
-
-    db.prepare('UPDATE businesses SET status = ? WHERE id = ?').run('site_built', businessId);
-    if (currentPipelineId) {
-      db.prepare('UPDATE pipeline_runs SET sites_built = sites_built + 1 WHERE id = ?').run(currentPipelineId);
-    }
-
-    // Email — template-based, no LLM tokens. Check counter in memory to avoid
-    // a SQL round-trip per lead; DB stays authoritative for restarts.
+    // Email — pitch the call with the Calendly link.
+    const calendlyLink = (process.env.CALENDLY_LINK || getSettingLink()) || '';
     if (enriched.owner_email && emailsSentToday < dailyEmailLimit) {
       emailsSentToday++;
-      const emailResult = await agents.postman.sendPitch(enriched, siteResult.previewUrl);
+      const emailResult = await agents.postman.sendPitch(enriched, calendlyLink);
       db.prepare(
         'INSERT INTO emails (business_id, site_id, to_email, to_name, subject, body, status, sent_at) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)'
-      ).run(businessId, siteRow.lastInsertRowid, enriched.owner_email, enriched.owner_name, emailResult.subject, emailResult.body, 'sent');
+      ).run(businessId, null, enriched.owner_email, enriched.owner_name, emailResult.subject, emailResult.body, 'sent');
 
-      // Postman uses templates today — only the SendGrid fixed cost applies.
       agents.pricer.trackBusinessCost(businessId, 'Postman', 0, 'default', 'email');
-
-      const pricing = agents.pricer.calculatePrice(businessId);
-      agents.pricer.log(`${enriched.name}: cost $${pricing.cost.toFixed(4)} → price $${pricing.finalPrice}`);
 
       if (currentPipelineId) {
         db.prepare('UPDATE pipeline_runs SET emails_sent = emails_sent + 1 WHERE id = ?').run(currentPipelineId);
@@ -235,6 +213,11 @@ async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
     if (currentPipelineId) {
       db.prepare('UPDATE pipeline_runs SET businesses_found = ? WHERE id = ?').run(totalProcessed, currentPipelineId);
     }
+  }
+
+  function getSettingLink() {
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'calendly_link'").get();
+    return row?.value || '';
   }
 
   // Run up to `concurrency` leads at a time per Scout call. Errors are

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -153,112 +153,115 @@ app.get('/api/pipeline/status', (req, res) => {
 
 async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
   const db = getDb();
-  let totalProcessed = 0;
   const builderAgents = [agents.builderAlpha, agents.builderBeta, agents.builderGamma];
+  const concurrency = builderAgents.length;
+  let totalProcessed = 0;
   let builderIndex = 0;
+  let emailsSentToday = db.prepare(
+    "SELECT COUNT(*) as count FROM emails WHERE date(sent_at) = date('now') AND status = 'sent'"
+  ).get().count;
+
+  async function processLead(biz) {
+    // Scraper enriches data
+    const enriched = await agents.scraper.enrichBusiness(biz);
+
+    // Save to database
+    const existing = db.prepare('SELECT id FROM businesses WHERE place_id = ?').get(enriched.place_id);
+    let businessId;
+    if (existing) {
+      businessId = existing.id;
+    } else {
+      const result = db.prepare(
+        `INSERT INTO businesses (place_id, name, address, phone, category, rating, review_count, hours, photos, services, owner_name, owner_email, zip_code, raw_data, status, priority)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        enriched.place_id, enriched.name, enriched.address, enriched.phone,
+        enriched.category, enriched.rating, enriched.review_count,
+        JSON.stringify(enriched.hours), JSON.stringify(enriched.photos),
+        JSON.stringify(enriched.services), enriched.owner_name, enriched.owner_email,
+        biz.zip_code || enriched.address?.match(/\b\d{5}\b/)?.[0] || null,
+        JSON.stringify(enriched), 'scraped',
+        enriched.rating ? Math.round(enriched.rating * (enriched.review_count || 0)) : 0
+      );
+      businessId = result.lastInsertRowid;
+    }
+
+    // Scout/Scraper don't use LLM tokens — only Places API fixed costs.
+    agents.pricer.trackBusinessCost(businessId, 'Scout', 0, 'default', 'find');
+    agents.pricer.trackBusinessCost(businessId, 'Scraper', 0, 'default', 'scrape');
+
+    // Round-robin across builder pool
+    const builder = builderAgents[builderIndex++ % builderAgents.length];
+    agents.commander.log(`Assigning ${enriched.name} to ${builder.name}`);
+
+    const siteResult = await builder.buildSite(enriched);
+
+    const siteRow = db.prepare(
+      'INSERT INTO sites (business_id, builder_agent, html_path, preview_url, build_time_ms, design_style, status) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(businessId, builder.name, siteResult.htmlPath, siteResult.previewUrl, siteResult.buildTime, siteResult.designStyle, 'completed');
+
+    // Real token usage from Claude's response.usage when available.
+    if (siteResult.usage) {
+      agents.accountant.trackUsage(builder.name, siteResult.usage, siteResult.model);
+      agents.pricer.trackBusinessCost(businessId, builder.name, siteResult.usage, siteResult.model, 'build');
+    }
+
+    db.prepare('UPDATE businesses SET status = ? WHERE id = ?').run('site_built', businessId);
+    if (currentPipelineId) {
+      db.prepare('UPDATE pipeline_runs SET sites_built = sites_built + 1 WHERE id = ?').run(currentPipelineId);
+    }
+
+    // Email — template-based, no LLM tokens. Check counter in memory to avoid
+    // a SQL round-trip per lead; DB stays authoritative for restarts.
+    if (enriched.owner_email && emailsSentToday < dailyEmailLimit) {
+      emailsSentToday++;
+      const emailResult = await agents.postman.sendPitch(enriched, siteResult.previewUrl);
+      db.prepare(
+        'INSERT INTO emails (business_id, site_id, to_email, to_name, subject, body, status, sent_at) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)'
+      ).run(businessId, siteRow.lastInsertRowid, enriched.owner_email, enriched.owner_name, emailResult.subject, emailResult.body, 'sent');
+
+      // Postman uses templates today — only the SendGrid fixed cost applies.
+      agents.pricer.trackBusinessCost(businessId, 'Postman', 0, 'default', 'email');
+
+      const pricing = agents.pricer.calculatePrice(businessId);
+      agents.pricer.log(`${enriched.name}: cost $${pricing.cost.toFixed(4)} → price $${pricing.finalPrice}`);
+
+      if (currentPipelineId) {
+        db.prepare('UPDATE pipeline_runs SET emails_sent = emails_sent + 1 WHERE id = ?').run(currentPipelineId);
+      }
+    }
+
+    totalProcessed++;
+    if (currentPipelineId) {
+      db.prepare('UPDATE pipeline_runs SET businesses_found = ? WHERE id = ?').run(totalProcessed, currentPipelineId);
+    }
+  }
+
+  // Run up to `concurrency` leads at a time per Scout call. Errors are
+  // caught per-lead so one failure doesn't poison the batch.
+  async function runInPool(leads) {
+    const cursor = { i: 0 };
+    const worker = async () => {
+      while (cursor.i < leads.length && pipelineRunning && totalProcessed < maxLeads) {
+        const idx = cursor.i++;
+        try {
+          await processLead(leads[idx]);
+        } catch (err) {
+          console.error('[Pipeline] Lead failed:', err.message);
+          broadcast('pipeline_error', { error: err.message, lead: leads[idx]?.name });
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: concurrency }, worker));
+  }
 
   for (const zip of zipCodes) {
     if (!pipelineRunning) break;
-
     for (const category of categories) {
       if (!pipelineRunning || totalProcessed >= maxLeads) break;
-
-      // Scout finds businesses
       const businesses = await agents.scout.findBusinesses(zip, category, maxLeads - totalProcessed);
-
-      for (const biz of businesses) {
-        if (!pipelineRunning || totalProcessed >= maxLeads) break;
-
-        // Scraper enriches data
-        const enriched = await agents.scraper.enrichBusiness(biz);
-
-        // Save to database
-        const existing = db.prepare('SELECT id FROM businesses WHERE place_id = ?').get(enriched.place_id);
-        let businessId;
-
-        if (existing) {
-          businessId = existing.id;
-        } else {
-          const result = db.prepare(
-            `INSERT INTO businesses (place_id, name, address, phone, category, rating, review_count, hours, photos, services, owner_name, owner_email, zip_code, raw_data, status, priority)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-          ).run(
-            enriched.place_id, enriched.name, enriched.address, enriched.phone,
-            enriched.category, enriched.rating, enriched.review_count,
-            JSON.stringify(enriched.hours), JSON.stringify(enriched.photos),
-            JSON.stringify(enriched.services), enriched.owner_name, enriched.owner_email,
-            zip, JSON.stringify(enriched), 'scraped',
-            enriched.rating ? Math.round(enriched.rating * enriched.review_count) : 0
-          );
-          businessId = result.lastInsertRowid;
-        }
-
-        // Track tokens (global)
-        agents.accountant.trackUsage('Scout', 150);
-        agents.accountant.trackUsage('Scraper', 200);
-
-        // Track per-business costs for dynamic pricing
-        agents.pricer.trackBusinessCost(businessId, 'Scout', 150, 'default', 'find');
-        agents.pricer.trackBusinessCost(businessId, 'Scraper', 200, 'default', 'scrape');
-
-        // Commander assigns to a builder (round-robin)
-        const builder = builderAgents[builderIndex % 3];
-        builderIndex++;
-
-        agents.commander.log(`Assigning ${enriched.name} to ${builder.name}`);
-
-        // Build site
-        const siteResult = await builder.buildSite(enriched);
-
-        const siteRow = db.prepare(
-          'INSERT INTO sites (business_id, builder_agent, html_path, preview_url, build_time_ms, design_style, status) VALUES (?, ?, ?, ?, ?, ?, ?)'
-        ).run(businessId, builder.name, siteResult.htmlPath, siteResult.previewUrl, siteResult.buildTime, siteResult.designStyle, 'completed');
-
-        agents.accountant.trackUsage(builder.name, 2000);
-        agents.pricer.trackBusinessCost(businessId, builder.name, 2000, 'claude-sonnet-4-6', 'build');
-
-        db.prepare('UPDATE businesses SET status = ? WHERE id = ?').run('site_built', businessId);
-
-        // Update pipeline stats
-        if (currentPipelineId) {
-          db.prepare('UPDATE pipeline_runs SET sites_built = sites_built + 1 WHERE id = ?').run(currentPipelineId);
-        }
-
-        // Send email if we have an email address
-        if (enriched.owner_email) {
-          const emailsSentToday = db.prepare(
-            "SELECT COUNT(*) as count FROM emails WHERE date(sent_at) = date('now') AND status = 'sent'"
-          ).get();
-
-          if (emailsSentToday.count < dailyEmailLimit) {
-            const emailResult = await agents.postman.sendPitch(enriched, siteResult.previewUrl);
-
-            db.prepare(
-              'INSERT INTO emails (business_id, site_id, to_email, to_name, subject, body, status, sent_at) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)'
-            ).run(businessId, siteRow.lastInsertRowid, enriched.owner_email, enriched.owner_name, emailResult.subject, emailResult.body, 'sent');
-
-            agents.accountant.trackUsage('Postman', 500);
-            agents.pricer.trackBusinessCost(businessId, 'Postman', 500, 'default', 'email');
-
-            // Calculate dynamic price for this business
-            const pricing = agents.pricer.calculatePrice(businessId);
-            agents.pricer.log(`${enriched.name}: cost $${pricing.cost.toFixed(4)} → price $${pricing.finalPrice}`);
-
-            if (currentPipelineId) {
-              db.prepare('UPDATE pipeline_runs SET emails_sent = emails_sent + 1 WHERE id = ?').run(currentPipelineId);
-            }
-          }
-        }
-
-        totalProcessed++;
-
-        if (currentPipelineId) {
-          db.prepare('UPDATE pipeline_runs SET businesses_found = ? WHERE id = ?').run(totalProcessed, currentPipelineId);
-        }
-
-        // Small delay between businesses
-        await new Promise((r) => setTimeout(r, 500));
-      }
+      for (const b of businesses) b.zip_code = zip;
+      await runInPool(businesses);
     }
   }
 

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -15,6 +15,7 @@ import { Postman } from './agents/Postman.js';
 import { Accountant } from './agents/Accountant.js';
 import { Pricer } from './agents/Pricer.js';
 import { SentinelClient } from './agents/Sentinel.js';
+import { registerBuilders } from './services/builderDispatch.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 3001;
@@ -58,6 +59,13 @@ function initAgents() {
   agents.accountant = new Accountant(broadcast);
   agents.pricer = new Pricer(broadcast);
   agents.sentinel = new SentinelClient(broadcast);
+
+  // Register builders so the Calendly webhook + manual "build demo" button
+  // can build outside the main pipeline.
+  registerBuilders(
+    [agents.builderAlpha, agents.builderBeta, agents.builderGamma],
+    { db: getDb(), broadcast, accountant: agents.accountant, pricer: agents.pricer },
+  );
 }
 
 initAgents();

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -16,6 +16,15 @@ import { Accountant } from './agents/Accountant.js';
 import { Pricer } from './agents/Pricer.js';
 import { SentinelClient } from './agents/Sentinel.js';
 import { registerBuilders } from './services/builderDispatch.js';
+import {
+  requestId,
+  securityHeaders,
+  rateLimit,
+  corsOriginList,
+  notFound,
+  errorHandler,
+  accessLog,
+} from './services/http.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 3001;
@@ -24,8 +33,28 @@ const app = express();
 const server = createServer(app);
 
 // Middleware
-app.use(cors());
-app.use(express.json());
+app.set('trust proxy', 1);
+app.use(requestId());
+app.use(securityHeaders());
+app.use(cors({ origin: corsOriginList(), credentials: true }));
+app.use(express.json({ limit: '1mb' }));
+app.use(accessLog());
+
+// Health endpoints — cheap checks used by uptime monitors + load balancers.
+app.get('/healthz', (req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
+app.get('/readyz', (req, res) => {
+  try {
+    getDb().prepare('SELECT 1').get();
+    res.json({ ok: true, db: 'ok', ts: new Date().toISOString() });
+  } catch (err) {
+    res.status(503).json({ ok: false, db: err.message });
+  }
+});
+
+// Rate limits on the externally-triggered write endpoints.
+app.use('/api/deploy', rateLimit({ max: 3, windowMs: 60_000, name: 'deploy' }));
+app.use('/api/stop', rateLimit({ max: 10, windowMs: 60_000, name: 'stop' }));
+app.use('/api/calendly/webhook', rateLimit({ max: 60, windowMs: 60_000, name: 'calendly' }));
 
 // Serve generated sites
 app.use('/sites', express.static(path.join(__dirname, '..', 'generated-sites')));
@@ -266,12 +295,27 @@ async function runPipeline(zipCodes, categories, maxLeads, dailyEmailLimit) {
   broadcast('pipeline_status', { status: 'completed' });
 }
 
-// SPA fallback
-app.get('*', (req, res) => {
+// SPA fallback — but let /api/* fall through to 404 + error handler below.
+app.get(/^(?!\/api\/).*/, (req, res) => {
   res.sendFile(path.join(__dirname, '..', 'client', 'dist', 'index.html'));
 });
 
+// 404 + error envelope (last)
+app.use('/api', notFound());
+app.use(errorHandler());
+
+// Graceful shutdown — give in-flight requests a moment to finish.
+function shutdown(signal) {
+  console.log(JSON.stringify({ level: 'info', event: 'shutdown', signal }));
+  pipelineRunning = false;
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 10_000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
 server.listen(PORT, () => {
-  console.log(`[Server] Website Scaler running on http://localhost:${PORT}`);
-  console.log(`[Server] WebSocket on same port`);
+  console.log(JSON.stringify({
+    level: 'info', event: 'server_started', port: PORT, ts: new Date().toISOString(),
+  }));
 });

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -145,23 +145,37 @@ router.get('/businesses', (req, res) => {
   const db = getDb();
   const limit = Math.min(500, parseInt(req.query.limit) || 100);
 
-  const wheres = [];
+  const wheres = ['(b.deleted_at IS NULL)'];
   const params = [];
+  let fromClause = 'FROM businesses b';
+
   if (req.query.q) {
-    wheres.push('(name LIKE ? OR address LIKE ? OR phone LIKE ?)');
-    const like = `%${req.query.q}%`;
-    params.push(like, like, like);
+    // Prefer FTS5 when it's available — it's dramatically faster than LIKE
+    // on large lead lists. The MATCH tokens get quoted so the user can pass
+    // plain text (the FTS5 parser treats `.`/`-` as syntax otherwise).
+    const fts = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='businesses_fts'")
+      .get();
+    if (fts) {
+      fromClause = 'FROM businesses b JOIN businesses_fts f ON f.rowid = b.id';
+      wheres.push('businesses_fts MATCH ?');
+      params.push(`"${String(req.query.q).replace(/"/g, '""')}"*`);
+    } else {
+      wheres.push('(b.name LIKE ? OR b.address LIKE ? OR b.phone LIKE ?)');
+      const like = `%${req.query.q}%`;
+      params.push(like, like, like);
+    }
   }
-  if (req.query.zip) { wheres.push('zip_code = ?'); params.push(req.query.zip); }
-  if (req.query.category) { wheres.push('category = ?'); params.push(req.query.category); }
-  if (req.query.status) { wheres.push('status = ?'); params.push(req.query.status); }
+  if (req.query.zip) { wheres.push('b.zip_code = ?'); params.push(req.query.zip); }
+  if (req.query.category) { wheres.push('b.category = ?'); params.push(req.query.category); }
+  if (req.query.status) { wheres.push('b.status = ?'); params.push(req.query.status); }
 
   const sql = `
-    SELECT id, place_id, name, address, phone, category, rating, review_count,
-           zip_code, status, priority, owner_name, owner_email, created_at
-    FROM businesses
-    ${wheres.length ? 'WHERE ' + wheres.join(' AND ') : ''}
-    ORDER BY priority DESC, created_at DESC
+    SELECT b.id, b.place_id, b.name, b.address, b.phone, b.category, b.rating, b.review_count,
+           b.zip_code, b.status, b.priority, b.owner_name, b.owner_email, b.created_at
+    ${fromClause}
+    WHERE ${wheres.join(' AND ')}
+    ORDER BY b.priority DESC, b.created_at DESC
     LIMIT ?
   `;
   const businesses = db.prepare(sql).all(...params, limit);

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -139,12 +139,38 @@ router.get('/pipelines', (req, res) => {
   res.json(pipelines);
 });
 
-// Businesses
+// Businesses — supports ?q=text&zip=X&category=Y&status=Z&limit=N
 router.get('/businesses', (req, res) => {
   const db = getDb();
-  const limit = parseInt(req.query.limit) || 50;
-  const businesses = db.prepare('SELECT * FROM businesses ORDER BY created_at DESC LIMIT ?').all(limit);
-  res.json(businesses);
+  const limit = Math.min(500, parseInt(req.query.limit) || 100);
+
+  const wheres = [];
+  const params = [];
+  if (req.query.q) {
+    wheres.push('(name LIKE ? OR address LIKE ? OR phone LIKE ?)');
+    const like = `%${req.query.q}%`;
+    params.push(like, like, like);
+  }
+  if (req.query.zip) { wheres.push('zip_code = ?'); params.push(req.query.zip); }
+  if (req.query.category) { wheres.push('category = ?'); params.push(req.query.category); }
+  if (req.query.status) { wheres.push('status = ?'); params.push(req.query.status); }
+
+  const sql = `
+    SELECT id, place_id, name, address, phone, category, rating, review_count,
+           zip_code, status, priority, owner_name, owner_email, created_at
+    FROM businesses
+    ${wheres.length ? 'WHERE ' + wheres.join(' AND ') : ''}
+    ORDER BY priority DESC, created_at DESC
+    LIMIT ?
+  `;
+  const businesses = db.prepare(sql).all(...params, limit);
+
+  // Distinct facets for the filter UI.
+  const zips = db.prepare("SELECT DISTINCT zip_code FROM businesses WHERE zip_code IS NOT NULL AND zip_code != '' ORDER BY zip_code").all().map((r) => r.zip_code);
+  const categories = db.prepare("SELECT DISTINCT category FROM businesses WHERE category IS NOT NULL AND category != '' ORDER BY category").all().map((r) => r.category);
+  const statuses = db.prepare("SELECT DISTINCT status FROM businesses WHERE status IS NOT NULL ORDER BY status").all().map((r) => r.status);
+
+  res.json({ businesses, facets: { zips, categories, statuses } });
 });
 
 // Pricing

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getDb } from '../database.js';
+import { buildDemoForBusiness } from '../services/builderDispatch.js';
 
 const router = Router();
 
@@ -290,7 +291,40 @@ router.post('/calendly/webhook', async (req, res) => {
     VALUES (?, ?, ?, ?, 'calendly', ?, 'scheduled')
   `).run(business.id, scheduledAt, bookerName, bookerEmail, providerEventId);
 
-  res.json({ ok: true, matched: true, callId: insert.lastInsertRowid, businessId: business.id });
+  const callId = insert.lastInsertRowid;
+
+  // Kick off the demo build asynchronously so the response returns fast.
+  // (Calendly retries on non-2xx, so we don't want to hold it open.)
+  buildDemoForBusiness(business.id, { reason: 'call_booked' })
+    .then(({ siteId }) => {
+      getDb()
+        .prepare('UPDATE scheduled_calls SET site_id = ?, status = ? WHERE id = ?')
+        .run(siteId, 'demo_built', callId);
+    })
+    .catch((err) => {
+      console.error('[Webhook] Demo build failed:', err.message);
+      getDb()
+        .prepare('UPDATE scheduled_calls SET status = ? WHERE id = ?')
+        .run('demo_failed', callId);
+    });
+
+  res.json({ ok: true, matched: true, callId, businessId: business.id });
+});
+
+// Manual "build demo now" trigger for the Scheduled Calls tab.
+router.post('/scheduled-calls/:id/build-demo', async (req, res) => {
+  const db = getDb();
+  const call = db.prepare('SELECT * FROM scheduled_calls WHERE id = ?').get(req.params.id);
+  if (!call) return res.status(404).json({ error: 'Call not found' });
+
+  try {
+    const { siteId, previewUrl } = await buildDemoForBusiness(call.business_id, { reason: 'manual' });
+    db.prepare('UPDATE scheduled_calls SET site_id = ?, status = ? WHERE id = ?')
+      .run(siteId, 'demo_built', call.id);
+    res.json({ ok: true, siteId, previewUrl });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 export default router;

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -229,4 +229,68 @@ router.get('/pricing/:businessId', (req, res) => {
   });
 });
 
+// Scheduled calls — populated by the Calendly webhook. Each row represents
+// a booked call where we need to build (or have already built) a demo site.
+router.get('/scheduled-calls', (req, res) => {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT sc.id, sc.scheduled_at, sc.booker_name, sc.booker_email, sc.status,
+           sc.business_id, sc.site_id,
+           b.name as business_name, b.category, b.address, b.phone,
+           b.rating, b.review_count,
+           s.preview_url, s.html_path
+    FROM scheduled_calls sc
+    LEFT JOIN businesses b ON b.id = sc.business_id
+    LEFT JOIN sites s ON s.id = sc.site_id
+    ORDER BY sc.scheduled_at ASC
+  `).all();
+  res.json(rows);
+});
+
+// Calendly webhook. Expects the `invitee.created` event payload. In the
+// user's Calendly booking form we ask for the business email or phone in
+// the "questions and answers" section; we use that to match to a lead.
+router.post('/calendly/webhook', async (req, res) => {
+  const db = getDb();
+  const event = req.body?.event;
+  const payload = req.body?.payload;
+
+  if (event !== 'invitee.created' || !payload) {
+    return res.json({ ok: true, ignored: true });
+  }
+
+  const bookerEmail = payload.email || payload.invitee?.email;
+  const bookerName = payload.name || payload.invitee?.name;
+  const scheduledAt = payload.scheduled_event?.start_time || payload.event?.start_time;
+  const providerEventId = payload.uri || payload.scheduled_event?.uri;
+
+  // Match by booker email first (most reliable — it's the owner_email we pitched).
+  let business = db.prepare('SELECT * FROM businesses WHERE owner_email = ?').get(bookerEmail);
+
+  // Fallback: look for a "business email" or "phone" answer in Calendly's Q&A.
+  if (!business && Array.isArray(payload.questions_and_answers)) {
+    const qa = payload.questions_and_answers;
+    const phoneAnswer = qa.find((q) => /phone/i.test(q.question))?.answer;
+    const emailAnswer = qa.find((q) => /email/i.test(q.question))?.answer;
+    if (emailAnswer) {
+      business = db.prepare('SELECT * FROM businesses WHERE owner_email = ?').get(emailAnswer);
+    }
+    if (!business && phoneAnswer) {
+      business = db.prepare('SELECT * FROM businesses WHERE phone = ?').get(phoneAnswer);
+    }
+  }
+
+  if (!business) {
+    // Stage the booking anyway — a human can reconcile it from the dashboard.
+    return res.status(202).json({ ok: true, matched: false });
+  }
+
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO scheduled_calls (business_id, scheduled_at, booker_name, booker_email, provider, provider_event_id, status)
+    VALUES (?, ?, ?, ?, 'calendly', ?, 'scheduled')
+  `).run(business.id, scheduledAt, bookerName, bookerEmail, providerEventId);
+
+  res.json({ ok: true, matched: true, callId: insert.lastInsertRowid, businessId: business.id });
+});
+
 export default router;

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
-import { getDb } from '../database.js';
+import crypto from 'crypto';
+import { getDb, getSetting } from '../database.js';
 import { buildDemoForBusiness } from '../services/builderDispatch.js';
 
 const router = Router();
@@ -309,6 +310,119 @@ router.post('/calendly/webhook', async (req, res) => {
     });
 
   res.json({ ok: true, matched: true, callId, businessId: business.id });
+});
+
+// Unsubscribe endpoint — hit by the link in the email footer (GET) and by
+// Gmail/Yahoo one-click (POST). Token is a truncated HMAC over the email,
+// which prevents an attacker from suppressing arbitrary addresses.
+function verifyUnsubToken(email, token) {
+  const secret = getSetting('calendly_webhook_secret') || 'scaler-dev-secret';
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(String(email || '').toLowerCase())
+    .digest('hex')
+    .slice(0, 16);
+  if (!token || token.length !== expected.length) return false;
+  // Timing-safe compare
+  return crypto.timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+}
+
+function recordUnsubscribe(email, req) {
+  const db = getDb();
+  db.prepare(
+    'INSERT OR IGNORE INTO suppressions (email, reason, source) VALUES (?, ?, ?)'
+  ).run(email.toLowerCase(), 'user_request', 'unsubscribe_link');
+  db.prepare('UPDATE emails SET unsubscribed = 1 WHERE to_email = ?').run(email);
+  db.prepare(
+    'INSERT INTO audit_log (actor, action, target_type, target_id, request_id, metadata) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('prospect', 'unsubscribe', 'email', email.toLowerCase(), req?.id || null, JSON.stringify({ ua: req?.headers?.['user-agent'] || '' }));
+}
+
+router.get('/unsubscribe', (req, res) => {
+  const email = String(req.query.e || '').trim();
+  const token = String(req.query.t || '').trim();
+  if (!email || !verifyUnsubToken(email, token)) {
+    return res.status(400).send('<!doctype html><body style="font-family:sans-serif"><h2>Invalid unsubscribe link</h2></body>');
+  }
+  recordUnsubscribe(email, req);
+  res.send(
+    '<!doctype html><body style="font-family:sans-serif;max-width:420px;margin:40px auto;text-align:center">' +
+    '<h2>You\'re unsubscribed</h2>' +
+    `<p>We won\'t email <strong>${email.replace(/</g, '&lt;')}</strong> again.</p>` +
+    '</body>'
+  );
+});
+
+router.post('/unsubscribe', (req, res) => {
+  const email = String(req.query.e || req.body?.email || '').trim();
+  const token = String(req.query.t || req.body?.token || '').trim();
+  if (!email || !verifyUnsubToken(email, token)) {
+    return res.status(400).json({ ok: false, error: 'invalid_token' });
+  }
+  recordUnsubscribe(email, req);
+  res.json({ ok: true });
+});
+
+// SendGrid event webhook (bounces, spam reports, unsubscribes).
+// Array of events per docs: https://docs.sendgrid.com/for-developers/tracking-events/event
+router.post('/sendgrid/events', (req, res) => {
+  const events = Array.isArray(req.body) ? req.body : [];
+  const db = getDb();
+  const insertSuppress = db.prepare(
+    'INSERT OR IGNORE INTO suppressions (email, reason, source) VALUES (?, ?, ?)'
+  );
+  const markBounced = db.prepare('UPDATE emails SET bounced = 1 WHERE to_email = ?');
+  const markUnsub = db.prepare('UPDATE emails SET unsubscribed = 1 WHERE to_email = ?');
+  const markOpened = db.prepare('UPDATE emails SET opened_at = COALESCE(opened_at, CURRENT_TIMESTAMP) WHERE to_email = ? AND opened_at IS NULL');
+  const markClicked = db.prepare('UPDATE emails SET clicked_at = COALESCE(clicked_at, CURRENT_TIMESTAMP) WHERE to_email = ?');
+
+  for (const ev of events) {
+    const email = (ev.email || '').toLowerCase();
+    if (!email) continue;
+    switch (ev.event) {
+      case 'bounce':
+      case 'dropped':
+        insertSuppress.run(email, `sendgrid_${ev.event}`, 'sendgrid_webhook');
+        markBounced.run(email);
+        break;
+      case 'spamreport':
+        insertSuppress.run(email, 'spam_report', 'sendgrid_webhook');
+        break;
+      case 'unsubscribe':
+      case 'group_unsubscribe':
+        insertSuppress.run(email, 'unsubscribe', 'sendgrid_webhook');
+        markUnsub.run(email);
+        break;
+      case 'open':
+        markOpened.run(email);
+        break;
+      case 'click':
+        markClicked.run(email);
+        break;
+    }
+  }
+  res.json({ ok: true, processed: events.length });
+});
+
+// Suppression list management
+router.get('/suppressions', (req, res) => {
+  const db = getDb();
+  const rows = db.prepare('SELECT * FROM suppressions ORDER BY created_at DESC LIMIT 500').all();
+  res.json(rows);
+});
+
+router.post('/suppressions', (req, res) => {
+  const email = String(req.body?.email || '').trim().toLowerCase();
+  if (!email) return res.status(400).json({ error: 'email required' });
+  getDb()
+    .prepare('INSERT OR IGNORE INTO suppressions (email, reason, source) VALUES (?, ?, ?)')
+    .run(email, req.body?.reason || 'manual', 'admin');
+  res.json({ ok: true });
+});
+
+router.delete('/suppressions/:email', (req, res) => {
+  getDb().prepare('DELETE FROM suppressions WHERE email = ?').run(String(req.params.email).toLowerCase());
+  res.json({ ok: true });
 });
 
 // Manual "build demo now" trigger for the Scheduled Calls tab.

--- a/dashboard/server/routes/api.js
+++ b/dashboard/server/routes/api.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import crypto from 'crypto';
 import { getDb, getSetting } from '../database.js';
 import { buildDemoForBusiness } from '../services/builderDispatch.js';
+import { verifyCalendly, verifySendGrid } from '../services/webhookSig.js';
 
 const router = Router();
 
@@ -280,6 +281,20 @@ router.get('/scheduled-calls', (req, res) => {
 // the "questions and answers" section; we use that to match to a lead.
 router.post('/calendly/webhook', async (req, res) => {
   const db = getDb();
+
+  // Signature verification — skipped when no secret configured (dev).
+  const secret = getSetting('calendly_webhook_secret');
+  if (secret) {
+    const verdict = verifyCalendly(
+      req.rawBody || '',
+      req.headers['calendly-webhook-signature'],
+      secret,
+    );
+    if (!verdict.ok && !verdict.skipped) {
+      return res.status(401).json({ error: 'invalid_signature', reason: verdict.reason });
+    }
+  }
+
   const event = req.body?.event;
   const payload = req.body?.payload;
 
@@ -392,6 +407,19 @@ router.post('/unsubscribe', (req, res) => {
 // SendGrid event webhook (bounces, spam reports, unsubscribes).
 // Array of events per docs: https://docs.sendgrid.com/for-developers/tracking-events/event
 router.post('/sendgrid/events', (req, res) => {
+  const pubKey = getSetting('sendgrid_webhook_public_key');
+  if (pubKey) {
+    const verdict = verifySendGrid(
+      req.rawBody || '',
+      req.headers['x-twilio-email-event-webhook-signature'],
+      req.headers['x-twilio-email-event-webhook-timestamp'],
+      pubKey,
+    );
+    if (!verdict.ok && !verdict.skipped) {
+      return res.status(401).json({ error: 'invalid_signature', reason: verdict.reason });
+    }
+  }
+
   const events = Array.isArray(req.body) ? req.body : [];
   const db = getDb();
   const insertSuppress = db.prepare(
@@ -465,6 +493,94 @@ router.post('/scheduled-calls/:id/build-demo', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// Update notes / outcome on a scheduled call.
+router.patch('/scheduled-calls/:id', (req, res) => {
+  const db = getDb();
+  const { notes, outcome, status } = req.body || {};
+  const call = db.prepare('SELECT * FROM scheduled_calls WHERE id = ?').get(req.params.id);
+  if (!call) return res.status(404).json({ error: 'Call not found' });
+
+  const updates = [];
+  const vals = [];
+  if (typeof notes === 'string') { updates.push('notes = ?'); vals.push(notes); }
+  if (typeof outcome === 'string' && /^(won|lost|follow_up|no_show)?$/.test(outcome)) {
+    updates.push('outcome = ?'); vals.push(outcome);
+  }
+  if (typeof status === 'string' && /^(scheduled|demo_built|demo_failed|completed|cancelled|no_show)$/.test(status)) {
+    updates.push('status = ?'); vals.push(status);
+  }
+  if (!updates.length) return res.json({ ok: true, unchanged: true });
+
+  vals.push(call.id);
+  db.prepare(`UPDATE scheduled_calls SET ${updates.join(', ')} WHERE id = ?`).run(...vals);
+
+  db.prepare(
+    'INSERT INTO audit_log (actor, action, target_type, target_id, request_id, metadata) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('operator', 'scheduled_call.update', 'scheduled_call', String(call.id), req.id || null, JSON.stringify({ notes: notes?.slice(0, 200), outcome, status }));
+
+  res.json({ ok: true });
+});
+
+// ICS export for a single call so the operator can add it to their own
+// calendar without relying on Calendly's invite pipeline.
+router.get('/scheduled-calls/:id/ics', (req, res) => {
+  const db = getDb();
+  const call = db.prepare(`
+    SELECT sc.*, b.name as business_name, b.address, b.phone
+    FROM scheduled_calls sc LEFT JOIN businesses b ON b.id = sc.business_id
+    WHERE sc.id = ?
+  `).get(req.params.id);
+  if (!call) return res.status(404).json({ error: 'Call not found' });
+
+  const start = toICS(call.scheduled_at);
+  const end = toICS(new Date(new Date(call.scheduled_at).getTime() + 15 * 60_000).toISOString());
+  const uid = `call-${call.id}@websitescaler`;
+  const summary = `Website demo call — ${call.business_name || 'Prospect'}`;
+  const description = [
+    call.business_name ? `Business: ${call.business_name}` : '',
+    call.address ? `Address: ${call.address}` : '',
+    call.phone ? `Phone: ${call.phone}` : '',
+    call.booker_name ? `Booked by: ${call.booker_name}` : '',
+    call.booker_email ? `Email: ${call.booker_email}` : '',
+  ].filter(Boolean).join('\\n');
+
+  const body = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Website Scaler//Scheduled Calls//EN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${toICS(new Date().toISOString())}`,
+    `DTSTART:${start}`,
+    `DTEND:${end}`,
+    `SUMMARY:${summary}`,
+    `DESCRIPTION:${description}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+
+  res.set({
+    'Content-Type': 'text/calendar; charset=utf-8',
+    'Content-Disposition': `attachment; filename="call-${call.id}.ics"`,
+  });
+  res.send(body);
+});
+
+function toICS(iso) {
+  if (!iso) return '';
+  return new Date(iso).toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+}
+
+// Audit log — read-only for now, ordered newest first, paginated.
+router.get('/audit-log', (req, res) => {
+  const limit = Math.min(500, parseInt(req.query.limit) || 100);
+  const offset = Math.max(0, parseInt(req.query.offset) || 0);
+  const rows = getDb()
+    .prepare('SELECT * FROM audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?')
+    .all(limit, offset);
+  res.json({ rows, limit, offset });
 });
 
 export default router;

--- a/dashboard/server/routes/settings.js
+++ b/dashboard/server/routes/settings.js
@@ -3,14 +3,17 @@ import { getDb, getSetting, setSetting } from '../database.js';
 
 const router = Router();
 
+// Settings keys that should be masked when returned to clients.
+const SENSITIVE_KEY = (key) =>
+  /api_key$/i.test(key) || /secret$/i.test(key) || /token$/i.test(key);
+
 router.get('/', (req, res) => {
   const db = getDb();
   const rows = db.prepare('SELECT key, value FROM settings').all();
   const settings = {};
   for (const row of rows) {
-    // Mask API keys for security
-    if (row.key.includes('api_key') && row.value) {
-      settings[row.key] = row.value ? '••••' + row.value.slice(-4) : '';
+    if (SENSITIVE_KEY(row.key) && row.value) {
+      settings[row.key] = '••••' + String(row.value).slice(-4);
     } else {
       settings[row.key] = row.value;
     }

--- a/dashboard/server/services/builderDispatch.js
+++ b/dashboard/server/services/builderDispatch.js
@@ -2,6 +2,8 @@
 // the Calendly webhook when a prospect books a call, and by the "build
 // demo now" button on the dashboard.
 
+import { withRetry, withTimeout } from './retry.js';
+
 let registry = null;
 
 export function registerBuilders(builders, deps) {
@@ -37,7 +39,15 @@ export async function buildDemoForBusiness(businessId, { reason = 'manual' } = {
   const builder = builders[registry.rr++ % builders.length];
   broadcast('demo_build_started', { businessId, reason, builder: builder.name });
 
-  const result = await builder.buildSite(enriched);
+  // Each build gets a 60s cap, and we retry once on a different builder if
+  // the first one blows up (e.g. LLM timeout, disk error).
+  const result = await withRetry(
+    async (attempt) => {
+      const b = attempt === 0 ? builder : builders[(registry.rr++) % builders.length];
+      return withTimeout(() => b.buildSite(enriched), 60_000, `build:${b.name}`);
+    },
+    { retries: 1, baseMs: 500, label: `build:${biz.id}` },
+  );
 
   const siteRow = db.prepare(
     'INSERT INTO sites (business_id, builder_agent, html_path, preview_url, build_time_ms, design_style, status) VALUES (?, ?, ?, ?, ?, ?, ?)'

--- a/dashboard/server/services/builderDispatch.js
+++ b/dashboard/server/services/builderDispatch.js
@@ -1,0 +1,57 @@
+// Shared dispatch for building demo sites outside the pipeline — used by
+// the Calendly webhook when a prospect books a call, and by the "build
+// demo now" button on the dashboard.
+
+let registry = null;
+
+export function registerBuilders(builders, deps) {
+  registry = { builders, deps, rr: 0 };
+}
+
+export async function buildDemoForBusiness(businessId, { reason = 'manual' } = {}) {
+  if (!registry) throw new Error('Builder registry not initialized');
+  const { builders, deps, rr } = registry;
+  const { db, broadcast, accountant, pricer } = deps;
+
+  const biz = db.prepare('SELECT * FROM businesses WHERE id = ?').get(businessId);
+  if (!biz) throw new Error(`Business ${businessId} not found`);
+
+  // Rehydrate enriched data from raw_data if present so the demo uses
+  // everything we scraped (services, hours, photos, reviews, editorial).
+  let enriched = { ...biz };
+  try {
+    if (biz.raw_data) {
+      const raw = JSON.parse(biz.raw_data);
+      enriched = { ...raw, id: biz.id };
+    }
+  } catch (_) {
+    // fall through with the flat row
+  }
+  // Ensure parsed fields are objects/arrays, not JSON strings.
+  for (const k of ['hours', 'photos', 'services']) {
+    if (typeof enriched[k] === 'string') {
+      try { enriched[k] = JSON.parse(enriched[k]); } catch (_) { /* ignore */ }
+    }
+  }
+
+  const builder = builders[registry.rr++ % builders.length];
+  broadcast('demo_build_started', { businessId, reason, builder: builder.name });
+
+  const result = await builder.buildSite(enriched);
+
+  const siteRow = db.prepare(
+    'INSERT INTO sites (business_id, builder_agent, html_path, preview_url, build_time_ms, design_style, status) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(biz.id, builder.name, result.htmlPath, result.previewUrl, result.buildTime, result.designStyle, 'completed');
+
+  if (result.usage && accountant) {
+    accountant.trackUsage(builder.name, result.usage, result.model);
+  }
+  if (result.usage && pricer) {
+    pricer.trackBusinessCost(biz.id, builder.name, result.usage, result.model, 'build');
+  }
+
+  db.prepare('UPDATE businesses SET status = ? WHERE id = ?').run('demo_built', biz.id);
+  broadcast('demo_build_completed', { businessId, siteId: siteRow.lastInsertRowid, previewUrl: result.previewUrl });
+
+  return { siteId: siteRow.lastInsertRowid, previewUrl: result.previewUrl };
+}

--- a/dashboard/server/services/http.js
+++ b/dashboard/server/services/http.js
@@ -1,0 +1,116 @@
+import { randomUUID } from 'crypto';
+
+// --- Request ID ------------------------------------------------------------
+// Attach a request ID to every request so we can correlate logs across stages.
+export function requestId() {
+  return (req, res, next) => {
+    const incoming = req.headers['x-request-id'];
+    req.id = typeof incoming === 'string' && incoming.length <= 64 ? incoming : randomUUID();
+    res.setHeader('X-Request-Id', req.id);
+    next();
+  };
+}
+
+// --- Security headers ------------------------------------------------------
+// Manual set — we don't want to pull `helmet` as a new dep. Matches the
+// sensible defaults helmet ships.
+export function securityHeaders() {
+  return (req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+    // HSTS only makes sense over HTTPS; the deployment environment sets it.
+    if (req.secure) {
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+    next();
+  };
+}
+
+// --- Simple in-memory rate limiter -----------------------------------------
+// Sliding-window-lite: bucket per key per `windowMs`. For multi-instance
+// deploys, swap in Redis — but this is good enough for single-box today.
+export function rateLimit({ windowMs = 60_000, max = 60, keyFn = (req) => req.ip, name = 'default' } = {}) {
+  const hits = new Map();
+  return (req, res, next) => {
+    const now = Date.now();
+    const key = `${name}:${keyFn(req)}`;
+    const entry = hits.get(key);
+    if (!entry || now - entry.start > windowMs) {
+      hits.set(key, { start: now, count: 1 });
+      return next();
+    }
+    entry.count++;
+    if (entry.count > max) {
+      res.setHeader('Retry-After', Math.ceil((entry.start + windowMs - now) / 1000));
+      return res.status(429).json({
+        error: 'Too many requests',
+        code: 'rate_limited',
+        retryAfter: Math.ceil((entry.start + windowMs - now) / 1000),
+      });
+    }
+    next();
+  };
+}
+
+// --- CORS allowlist --------------------------------------------------------
+// `process.env.CORS_ORIGINS` is a comma-separated list. Empty → allow all
+// (dev-friendly). Falls through to the cors package; this one just trims.
+export function corsOriginList() {
+  const raw = process.env.CORS_ORIGINS || '';
+  const list = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return list.length === 0 ? true : list;
+}
+
+// --- 404 + error envelope --------------------------------------------------
+export function notFound() {
+  return (req, res) => {
+    res.status(404).json({ error: 'Not found', code: 'not_found', path: req.path });
+  };
+}
+
+export function errorHandler() {
+  // 4-arity signature is required for Express to treat it as an error handler.
+  // eslint-disable-next-line no-unused-vars
+  return (err, req, res, next) => {
+    const status = err.status || err.statusCode || 500;
+    const body = {
+      error: err.expose ? err.message : status >= 500 ? 'Internal server error' : err.message,
+      code: err.code || (status >= 500 ? 'internal' : 'bad_request'),
+      requestId: req.id,
+    };
+    // Log with request-id so ops can correlate.
+    console.error(JSON.stringify({
+      level: 'error',
+      requestId: req.id,
+      method: req.method,
+      path: req.path,
+      status,
+      message: err.message,
+      stack: err.stack,
+    }));
+    res.status(status).json(body);
+  };
+}
+
+// --- Structured access log -------------------------------------------------
+export function accessLog() {
+  return (req, res, next) => {
+    const start = Date.now();
+    res.on('finish', () => {
+      // Skip the noisy polling endpoints — they'd flood the log.
+      if (req.path === '/api/pipeline/status' || req.path === '/api/activity') return;
+      console.log(JSON.stringify({
+        level: 'info',
+        ts: new Date().toISOString(),
+        requestId: req.id,
+        method: req.method,
+        path: req.path,
+        status: res.statusCode,
+        durationMs: Date.now() - start,
+      }));
+    });
+    next();
+  };
+}

--- a/dashboard/server/services/retry.js
+++ b/dashboard/server/services/retry.js
@@ -1,0 +1,49 @@
+// Small reusable retry + timeout helpers so every agent doesn't reinvent
+// them. Kept dep-free — just AbortController + Promises.
+
+export class TimeoutError extends Error {
+  constructor(ms, label) {
+    super(`Timed out after ${ms}ms${label ? ` (${label})` : ''}`);
+    this.name = 'TimeoutError';
+    this.code = 'timeout';
+  }
+}
+
+export function withTimeout(promiseOrFn, ms, label) {
+  const exec = typeof promiseOrFn === 'function' ? promiseOrFn() : promiseOrFn;
+  let timer;
+  const timeout = new Promise((_, rej) => {
+    timer = setTimeout(() => rej(new TimeoutError(ms, label)), ms);
+  });
+  return Promise.race([exec, timeout]).finally(() => clearTimeout(timer));
+}
+
+// Exponential backoff with jitter. `shouldRetry` defaults to "retry on
+// any error except 4xx-looking ones" (a status property less than 500 is
+// treated as terminal).
+export async function withRetry(fn, {
+  retries = 3,
+  baseMs = 300,
+  maxMs = 5_000,
+  shouldRetry = (err) => !(err && typeof err.status === 'number' && err.status >= 400 && err.status < 500),
+  onRetry = null,
+  label = '',
+} = {}) {
+  let attempt = 0;
+  let lastErr;
+  while (attempt <= retries) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      lastErr = err;
+      if (attempt === retries || !shouldRetry(err)) break;
+      const backoff = Math.min(maxMs, baseMs * 2 ** attempt);
+      const jitter = Math.floor(Math.random() * (backoff / 2));
+      const delay = backoff + jitter;
+      if (onRetry) onRetry({ attempt: attempt + 1, delay, err, label });
+      await new Promise((r) => setTimeout(r, delay));
+      attempt++;
+    }
+  }
+  throw lastErr;
+}

--- a/dashboard/server/services/webhookSig.js
+++ b/dashboard/server/services/webhookSig.js
@@ -1,0 +1,57 @@
+import crypto from 'crypto';
+
+// Calendly: `Calendly-Webhook-Signature: t=<unix>,v1=<hex>` where v1 is
+// HMAC-SHA256 of `${t}.${rawBody}` with the signing key.
+export function verifyCalendly(rawBody, headerValue, signingKey, toleranceSec = 300) {
+  if (!signingKey) return { ok: true, skipped: true };
+  if (!headerValue || typeof headerValue !== 'string') return { ok: false, reason: 'missing_header' };
+
+  const parts = Object.fromEntries(
+    headerValue.split(',').map((p) => {
+      const i = p.indexOf('=');
+      return i < 0 ? [p, ''] : [p.slice(0, i).trim(), p.slice(i + 1).trim()];
+    }),
+  );
+  const t = parts.t;
+  const v1 = parts.v1;
+  if (!t || !v1) return { ok: false, reason: 'malformed_header' };
+
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - Number(t)) > toleranceSec) return { ok: false, reason: 'stale' };
+
+  const expected = crypto
+    .createHmac('sha256', signingKey)
+    .update(`${t}.${rawBody}`)
+    .digest('hex');
+  return constantEq(expected, v1)
+    ? { ok: true }
+    : { ok: false, reason: 'bad_signature' };
+}
+
+// SendGrid: signed with an ECDSA public key. Verify using
+// `X-Twilio-Email-Event-Webhook-Signature` + `-Timestamp` headers and the
+// configured public key.
+export function verifySendGrid(rawBody, signature, timestamp, publicKey) {
+  if (!publicKey) return { ok: true, skipped: true };
+  if (!signature || !timestamp) return { ok: false, reason: 'missing_header' };
+
+  try {
+    const verifier = crypto.createVerify('sha256');
+    verifier.update(timestamp + rawBody);
+    verifier.end();
+    const keyPem = publicKey.includes('-----BEGIN')
+      ? publicKey
+      : `-----BEGIN PUBLIC KEY-----\n${publicKey}\n-----END PUBLIC KEY-----`;
+    const ok = verifier.verify(keyPem, signature, 'base64');
+    return ok ? { ok: true } : { ok: false, reason: 'bad_signature' };
+  } catch (err) {
+    return { ok: false, reason: `verify_error:${err.message}` };
+  }
+}
+
+function constantEq(a, b) {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}


### PR DESCRIPTION
Nine commits across four themes: **Scout quality**, **product pivot to "pitch a call, build demo after booking"**, **infra hardening**, and **new dashboard surfaces**.

## ⚠️ Overlap with #10

#10 ("Live cost tracking + daily budget cap") is still open. Commit `077a5a9` here overlaps with it on real `response.usage` wiring + per-model cost splits in Accountant/Pricer. If #10 merges first, the Builder/Accountant/Pricer changes in `077a5a9` should be dropped; everything else in this PR is independent.

## Theme 1 — Scout quality (`b32b081`, `077a5a9`)

- **No-website filter** expanded — Facebook / Yelp / Linktree / `business.site` / OpenTable / TripAdvisor / Instagram / Google Sites / Booksy / Zocdoc etc. are now treated as "no real website", so listings with social-only presence still qualify.
- **Category verification** in API mode with synonyms (cafe → restaurant, barber → salon, yoga → gym) so text search can't slip off-category listings in.
- **Cross-run dedupe** — skip `place_id`s already in the `businesses` table before Scraper ever runs.
- **DB indexes** on hot query paths (`businesses(zip_code, status)`, `emails(status, sent_at)`, `business_costs(business_id)`, `token_usage(created_at)`, etc.).
- **Real token accounting** — Builder returns `response.usage` + model; Accountant/Pricer cost input/output/cache-read/cache-write separately per model. The fake 150/200/500/2000 constants in the pipeline are gone.
- **Prompt-caching hint** (`cache_control: ephemeral`) on Builder's system block — a no-op today (prompt < 2048 tokens) but activates the day we add style guidance.
- **Bounded parallelism** — pipeline runs 3 leads concurrently through a worker pool matching the Builder count, with per-lead error isolation.

## Theme 2 — Calendly pivot (`e04093f`, `c4dda95`)

New flow: Postman pitches a 15-min call; Builder runs **after** the call is booked.

- `scheduled_calls` table + nullable `tenant_id` on the big tables (default 1) as phase-2 multi-tenant groundwork.
- `POST /api/calendly/webhook` — accepts `invitee.created`, matches booker to a business by `owner_email` or Q&A answers, inserts a `scheduled_calls` row, and asynchronously kicks off a demo build.
- `GET /api/scheduled-calls` — list joined with business + site info.
- `POST /api/scheduled-calls/:id/build-demo` — manual trigger for reruns.
- `services/builderDispatch.js` — shared helper; rehydrates enriched data from `businesses.raw_data` so the demo uses everything Scraper captured (services, hours, photos, reviews, editorial summary).
- Postman templates rewritten to pitch a 15-min call with the user's Calendly link.
- New **📅 Calls** dashboard tab — business, time, booker, status badge; "Open demo" / "Build demo" / "Rebuild" per row; auto-refreshes on `demo_build_started` / `demo_build_completed` WS events.

## Theme 3 — Infra hardening (`63cf779`, `1d64d7e`, `bb2a936`)

### API layer (`services/http.js`)
- Request-ID middleware (echoed in response + error bodies).
- Security headers (XFO, X-CTO, Referrer-Policy, Permissions-Policy, HSTS-if-secure).
- In-memory rate limiter on `/api/deploy`, `/api/stop`, `/api/calendly/webhook`.
- CORS origin allowlist via `CORS_ORIGINS` env.
- Consistent error envelope `{ error, code, requestId }`.
- Structured JSON access log.
- `/healthz` + `/readyz` endpoints.
- SIGTERM / SIGINT graceful shutdown.
- `GET /api/settings` masks `*_secret` and `*_token` in addition to `*_api_key`.

### Email compliance (CAN-SPAM + one-click unsubscribe)
- New `suppressions` table; Postman checks it before every send.
- Signed-HMAC unsubscribe link in every footer.
- `GET/POST /api/unsubscribe` with timing-safe token verify.
- `POST /api/sendgrid/events` — populates suppressions on bounce / spam report / unsubscribe; updates open/click timestamps.
- `List-Unsubscribe` + `List-Unsubscribe-Post` headers for Gmail/Yahoo one-click.
- Plaintext + HTML multipart body.
- Physical address + unsubscribe URL settings for CAN-SPAM footer.
- `GET / POST / DELETE /api/suppressions` admin endpoints.

### Scout / Scraper
- `businessStatus != OPERATIONAL` dropped.
- `min_review_count` setting.
- Normalized-phone dedupe across `businesses`.
- Scraper photo resolution is now parallel (up to 3 concurrent fetches).
- `enrichment_failures` table with upsert + attempt count.

### Builder (SEO + a11y on generated demos)
- `<meta description>`, theme-color, Open Graph, Twitter Card.
- `schema.org/LocalBusiness` JSON-LD with parsed hours + OfferCatalog of services.
- "Open now" / "Closed now" badge from parsed hours.
- Today's row highlighted in hours table.
- Real customer reviews section (first 3 from Scraper).
- `tel:` CTA; Get-directions CTA to `googleMapsUri`; `rel="noopener noreferrer"` on external links; `<iframe title>` for a11y.

### Sentinel
- Resource checks tick every 60s: SQLite DB size, WAL size, 5-min error rate, Node heap.
- `logIssueOnce()` dedupes alerts by tag so the issues panel doesn't flood.

### Retry / timeout
- New `services/retry.js` with `withTimeout(fn, ms, label)` + `withRetry(fn, { retries, baseMs, maxMs, shouldRetry, onRetry })`.
- Demo builds run inside a 60s cap, retry once on a different Builder.

## Theme 4 — New dashboard surfaces (`f1ccee3`, `2e442d8`)

- **🗂 Leads tab** — searchable table with debounced text search, zip / category / status filters, status badges, Reset. Backed by `GET /api/businesses?q=&zip=&category=&status=&limit=` with distinct-facets payload for the filter dropdowns.
- **Suppressions panel** in Settings — add/remove addresses backed by the admin endpoints.
- **Settings** has three new groups: Call Booking (Calendly link + webhook secret), Compliance (sender physical address, unsubscribe base URL), Lead Quality (min review count).
- **ErrorBoundary** keyed per page — switching tabs resets a crashed view.
- Document title updates per tab.

## Schema additions

- `scheduled_calls`, `suppressions`, `enrichment_failures`, `audit_log`.
- Nullable `tenant_id` on `businesses`, `sites`, `emails`, `sales`, `scheduled_calls` (default 1).
- Indexes on every new table + the hot paths on the existing ones.
- New default settings: `calendly_link`, `calendly_webhook_secret`, `sender_physical_address`, `unsubscribe_base_url`, `min_review_count`.

## Files

```
 dashboard/client/src/App.jsx                                    | 38 +++-
 dashboard/client/src/components/ErrorBoundary.jsx (new)         | 42 ++++
 dashboard/client/src/components/Leads.jsx (new)                 | 116 +++++++++++
 dashboard/client/src/components/ScheduledCalls.jsx (new)        | 170 ++++++++++++++++
 dashboard/client/src/components/Settings.jsx                    | 38 +++-
 dashboard/client/src/components/SuppressionsPanel.jsx (new)     |  83 ++++++++
 dashboard/server/agents/Accountant.js                           | 41 ++--
 dashboard/server/agents/BaseAgent.js                            |  8 +
 dashboard/server/agents/Builder.js                              | 140 ++++++++++++-
 dashboard/server/agents/Postman.js                              | 100 +++++++--
 dashboard/server/agents/Pricer.js                               | 38 ++--
 dashboard/server/agents/Scout.js                                | 78 +++++++-
 dashboard/server/agents/Scraper.js                              | 45 ++++-
 dashboard/server/agents/Sentinel.js                             | 93 ++++++++-
 dashboard/server/database.js                                    | 92 +++++++++-
 dashboard/server/index.js                                       | 160 +++++++++------
 dashboard/server/routes/api.js                                  | 226 ++++++++++++++++++++-
 dashboard/server/routes/settings.js                             |  10 +-
 dashboard/server/services/builderDispatch.js (new)              | 73 +++++++
 dashboard/server/services/http.js (new)                         | 107 ++++++++++
 dashboard/server/services/retry.js (new)                        | 49 +++++
```

## Test plan

- [ ] `cd dashboard && npm install` (picks up nothing new — no deps added)
- [ ] `npm run dev` and open http://localhost:5173
- [ ] **Mock mode sanity** — hit Deploy, watch the activity feed, verify leads show up under 🗂 Leads, emails flow to the Postman logs.
- [ ] **Unsubscribe flow** — grab the unsubscribe URL from a mock email body, open it, confirm the address appears in Settings → Email Suppressions.
- [ ] **Calendly webhook** — `curl -X POST http://localhost:3001/api/calendly/webhook -H 'Content-Type: application/json' -d '{"event":"invitee.created","payload":{"email":"<an owner_email from Leads>","name":"Test","scheduled_event":{"start_time":"2026-05-01T15:00:00Z"}}}'`. Should 200 with `matched: true`, show up under 📅 Calls, and kick off a build.
- [ ] Click "Open demo" on the new call → generated site opens with JSON-LD, Open Now badge, highlighted today's hours.
- [ ] **Health** — `curl http://localhost:3001/healthz` and `/readyz` return `{ ok: true }`.
- [ ] **Rate limit** — POST `/api/deploy` 4× in under a minute; 4th returns 429 with `Retry-After`.
- [ ] **Error envelope** — `curl http://localhost:3001/api/does-not-exist` returns `{ error, code, path }` JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpA61Xich5KkpGR5psaxDP)_