### PR TITLE
Scout: only return businesses rated ≥ 4.0 (no-website filter already in place)

### DIFF
--- a/dashboard/client/src/components/Settings.jsx
+++ b/dashboard/client/src/components/Settings.jsx
@@ -60,6 +60,13 @@ const LIMITS_FIELDS = [
     type: 'number',
     help: 'Throttle so it doesn\'t look like a burst.',
   },
+  {
+    key: 'min_rating',
+    label: 'Min Google rating',
+    type: 'number',
+    step: '0.1',
+    help: 'Scout only returns businesses at or above this rating. Default 4.0 — unrated listings are also skipped.',
+  },
 ];
 
 export default function Settings() {
@@ -221,15 +228,16 @@ export default function Settings() {
         );
       })}
 
-      {/* Limits */}
+      {/* Limits & Lead Quality */}
       <div className="card border border-dark-500 p-5 rounded-lg bg-dark-800/40">
-        <h2 className="text-lg font-semibold text-white mb-4">Limits</h2>
+        <h2 className="text-lg font-semibold text-white mb-4">Limits &amp; Lead Quality</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {LIMITS_FIELDS.map((field) => (
             <div key={field.key}>
               <label className="block text-xs text-gray-400 mb-1">{field.label}</label>
               <input
                 type={field.type}
+                step={field.step}
                 value={settings[field.key] ?? ''}
                 onChange={(e) => handleChange(field.key, e.target.value)}
                 className="w-full bg-dark-900 border border-dark-500 rounded-md px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"

--- a/dashboard/server/agents/Scout.js
+++ b/dashboard/server/agents/Scout.js
@@ -26,17 +26,22 @@ export class Scout extends BaseAgent {
   async findBusinesses(zipCode, category, limit = 10) {
     this.heartbeat();
     const apiKey = getSetting('google_maps_api_key');
+    const minRating = parseFloat(getSetting('min_rating')) || 0;
 
     if (apiKey) {
-      return this.findBusinessesFromApi(zipCode, category, limit, apiKey);
+      return this.findBusinessesFromApi(zipCode, category, limit, apiKey, minRating);
     }
 
     // Mock mode — no Google Maps key configured
-    this.log(`Searching for ${category} in ${zipCode} [MOCK: add Google Maps API key for real data]`, 'info');
+    this.log(
+      `Searching for ${category} in ${zipCode} (rating ≥ ${minRating || 'any'}) [MOCK: add Google Maps API key for real data]`,
+      'info',
+    );
     await this.simulateDelay(800, 2000);
 
     const filtered = MOCK_BUSINESSES
       .filter((b) => !category || b.category === category || category === 'all')
+      .filter((b) => !minRating || (b.rating || 0) >= minRating)
       .slice(0, limit)
       .map((b) => ({
         ...b,
@@ -44,12 +49,15 @@ export class Scout extends BaseAgent {
         address: `${b.address}, ${zipCode}`,
       }));
 
-    this.log(`Found ${filtered.length} businesses without websites in ${zipCode}`, 'success');
+    this.log(
+      `Found ${filtered.length} businesses without websites in ${zipCode} (rated ≥ ${minRating || 0})`,
+      'success',
+    );
     this.completeTask();
     return filtered;
   }
 
-  async findBusinessesFromApi(zipCode, category, limit, apiKey) {
+  async findBusinessesFromApi(zipCode, category, limit, apiKey, minRating = 0) {
     // Places API (New) v1 Text Search. Field mask keeps cost minimal — we only
     // pay for fields we request. `websiteUri` is how we filter: if the listing
     // has a website, we skip it (that's our qualifier — they don't need us).
@@ -71,6 +79,9 @@ export class Scout extends BaseAgent {
     const qualified = [];
     let pageToken;
     let requestsMade = 0;
+    let skippedHasWebsite = 0;
+    let skippedLowRating = 0;
+    let skippedNoRating = 0;
 
     try {
       do {
@@ -102,7 +113,17 @@ export class Scout extends BaseAgent {
         logGoogleMapsUsage({ agent: this.name, sku: 'text_search' });
 
         for (const p of data.places || []) {
-          if (p.websiteUri) continue; // already has a site — skip
+          if (p.websiteUri) { skippedHasWebsite++; continue; }
+
+          // Rating gate — default 4.0. We skip unrated listings too: if Google
+          // has no stars for them, they're almost never real ongoing businesses,
+          // and they've never proven they're worth pitching.
+          if (minRating > 0) {
+            const rating = p.rating;
+            if (rating == null) { skippedNoRating++; continue; }
+            if (rating < minRating) { skippedLowRating++; continue; }
+          }
+
           qualified.push({
             place_id: p.id,
             name: p.displayName?.text || '',
@@ -122,7 +143,9 @@ export class Scout extends BaseAgent {
       } while (pageToken && qualified.length < limit && requestsMade < 3);
 
       this.log(
-        `Found ${qualified.length} businesses without websites in ${zipCode} (${requestsMade} API calls)`,
+        `Found ${qualified.length} leads (no website, rated ≥ ${minRating || 0}) in ${zipCode} — ` +
+          `${requestsMade} API calls; skipped ${skippedHasWebsite} with site, ` +
+          `${skippedLowRating} below threshold, ${skippedNoRating} unrated`,
         qualified.length > 0 ? 'success' : 'warning',
       );
       this.completeTask();

--- a/dashboard/server/database.js
+++ b/dashboard/server/database.js
@@ -195,6 +195,7 @@ function initSchema() {
     max_emails_per_hour: '50',
     site_base_url: 'http://localhost:3001/sites',
     daily_budget_usd: '5',
+    min_rating: '4.0',
     current_price: '50',
     avg_cost_per_business: '0',
     price_sample_size: '0',


### PR DESCRIPTION
Scout already filters out businesses that have a website. This adds the second qualifier you asked for — minimum rating, default 4.0.

## What changes
- New `min_rating` setting (default `'4.0'`) added to defaults in `database.js`.
- `Scout.findBusinesses()` reads it once and applies the gate in both the Places API path and the mock-mode path.
- Unrated listings (`rating == null`) are also skipped — they're almost always defunct or never-claimed listings, never worth pitching.
- Skip counters in the success log now break out `hasWebsite / lowRating / unrated` so it's obvious what got filtered.
- Settings → "Limits & Lead Quality" now has a `Min Google rating` field (step 0.1) with helper text.

## Why now
Branched off the freshly-merged `main` (post #10). Surgical: 3 files, +40/-8. No overlap with @Hangry69's cost-tracker / pricer / email-templates work.

## Test plan
- [ ] `cd dashboard && npm run dev`
- [ ] Mock mode: hit Deploy. Activity feed should show e.g. `Found 9 businesses without websites in 90210 (rated ≥ 4)` (Joe's Auto Repair @4.3 stays; Thompson Law @4.2 stays; nothing under 4.0 in mock).
- [ ] Set Min Google rating to `4.6` in Settings, save, redeploy → fewer mocks pass.
- [ ] With a real Google Maps key: `Found N leads (no website, rated ≥ 4) in 90210 — X API calls; skipped Y with site, Z below threshold, W unrated`.

cc @Hangry69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpA61Xich5KkpGR5psaxDP)_